### PR TITLE
Adhere to Turbo expectations for redirects

### DIFF
--- a/app/controllers/uchi/repository_controller.rb
+++ b/app/controllers/uchi/repository_controller.rb
@@ -11,7 +11,7 @@ module Uchi
     def create
       @record = build_record
       if @record.save
-        redirect_to(@repository.routes.path_for(:show, id: @record.id), notice: "Office created successfully.")
+        redirect_to(@repository.routes.path_for(:show, id: @record.id), notice: "Office created successfully.", status: :see_other)
       else
         render :new, status: :unprocessable_entity
       end
@@ -56,7 +56,7 @@ module Uchi
       @record = find_record
       if @record.update(record_params)
         flash[:notice] = @repository.translate.successful_update
-        redirect_to(@repository.routes.path_for(:show, id: @record.id))
+        redirect_to(@repository.routes.path_for(:show, id: @record.id), status: :see_other)
       else
         render :edit, status: :unprocessable_entity
       end

--- a/test/controllers/uchi/authors_controller_test.rb
+++ b/test/controllers/uchi/authors_controller_test.rb
@@ -51,6 +51,11 @@ module Uchi
       assert_redirected_to uchi_author_url(id: @author.id)
     end
 
+    test "PATCH update responds with 303 after successful update" do
+      patch uchi_author_url(id: @author.id), params: {author: {name: "Updated Name"}}
+      assert_response :see_other
+    end
+
     test "PATCH update changes the author's attributes" do
       patch uchi_author_url(id: @author.id), params: {author: {name: "Updated Name"}}
       @author.reload
@@ -82,6 +87,11 @@ module Uchi
     test "POST create redirects to show after successful creation" do
       post uchi_authors_url, params: {author: {name: "New Author"}}
       assert_redirected_to uchi_author_url(id: Author.last.id)
+    end
+
+    test "POST create responds with 303 after successful creation" do
+      post uchi_authors_url, params: {author: {name: "New Author"}}
+      assert_response :see_other
     end
 
     test "POST create creates a new author" do


### PR DESCRIPTION
> After a stateful request from a form submission, Turbo Drive expects
> the server to return an HTTP 303 redirect response, which it will then
> follow and use to navigate and update the page without reloading.

https://turbo.hotwired.dev/handbook/drive#redirecting-after-a-form-submission