### PR TITLE
Add option to configure fields for :new pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Fields can now be configured to appear on :new pages, but not on :edit, and vice versa. Either add or remove `:new` from the fields `on()` configuration as needed.
+
 ### Fixed
 
 - Allow UI to use the full height of the viewport to prevent clipping popovers and dialogs.

--- a/app/controllers/uchi/repository_controller.rb
+++ b/app/controllers/uchi/repository_controller.rb
@@ -9,7 +9,7 @@ module Uchi
     before_action :set_repository
 
     def create
-      @record = build_record
+      @record = build_record_for_new
       if @record.save
         flash[:success] = @repository.translate.successful_create
         redirect_to(@repository.routes.path_for(:show, id: @record.id), status: :see_other)
@@ -54,7 +54,7 @@ module Uchi
     end
 
     def new
-      @record = build_record
+      @record = build_record_for_new
     end
 
     def show
@@ -63,7 +63,7 @@ module Uchi
 
     def update
       @record = find_record
-      if @record.update(record_params)
+      if @record.update(record_params_for_update)
         flash[:success] = @repository.translate.successful_update
         redirect_to(@repository.routes.path_for(:show, id: @record.id, uniq: rand), status: :see_other)
       else
@@ -73,8 +73,8 @@ module Uchi
 
     private
 
-    def build_record
-      @repository.build(record_params)
+    def build_record_for_new
+      @repository.build(record_params_for_new)
     end
 
     # Returns the path to use for the cancel link
@@ -128,10 +128,26 @@ module Uchi
       25
     end
 
-    def record_params
-      permitted_params = @repository.fields_for_edit.map(&:permitted_param)
+    def permitted_params_for_edit
+      @repository.fields_for_edit.map(&:permitted_param)
+    end
+
+    def permitted_params_for_new
+      @repository.fields_for_new.map(&:permitted_param)
+    end
+
+    def record_params_for_edit
       (params[@repository.model_param_key] || ActionController::Parameters.new)
-        .permit(*permitted_params)
+        .permit(*permitted_params_for_edit)
+    end
+
+    def record_params_for_update
+      record_params_for_edit
+    end
+
+    def record_params_for_new
+      (params[@repository.model_param_key] || ActionController::Parameters.new)
+        .permit(*permitted_params_for_new)
     end
 
     # Returns the repository class associated with this controller.

--- a/app/views/uchi/repository/new.html.erb
+++ b/app/views/uchi/repository/new.html.erb
@@ -15,10 +15,10 @@
 <%= render(Uchi::Flowbite::Card.new) do %>
   <%= form_with model: @record, url: @repository.routes.path_for(:create) do |form| %>
     <div class="space-y-6">
-      <% @repository.fields_for_edit.each do |field| %>
+      <% @repository.fields_for_new.each do |field| %>
         <div>
           <%= render(
-            field.edit_component(
+            field.new_component(
               form: form,
               repository: @repository,
               label: @repository.translate.field_label(field),

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -142,6 +142,23 @@ The lambda receives an `ActiveRecord::Relation` with all records returned from t
 
 The dropdown displays the `title` of the record. For example, a `Person` repository may use the `name` attribute as its title. To customize the title for a record, implement `Repository#title`, see [repositories documentation](repositories/#customizing-the-title-of-a-record) for details.
 
+### BelongsTo field for polymorphic associations
+
+Out of the box, `Field::BelongsTo` works for regular `belongs_to` associations as well as polymorphic ones. However, for polymorphic associations the field cannot be shown on `new` pages since Uchi cannot guess what models to show in the associated record dropdown, which causes an exception.
+
+For now, the best workaround is to remove the `BelongsTo` field from `:new` and add explicit fields for the polymorphic attributes instead, ie:
+
+```ruby
+def fields
+  [
+    Field::BelongsTo.new(:owner).on(:edit, :index, :show),
+    Field::String.new(:owner_type).on(:new),
+    Field::Number.new(:owner_id).on(:new),
+  ]
+end
+```
+
+or create a custom field that provides a user interface to select whatever models you want to choose between.
 
 ## Field::HasMany
 

--- a/lib/uchi/field.rb
+++ b/lib/uchi/field.rb
@@ -51,6 +51,17 @@ module Uchi
       @name = name.to_sym
     end
 
+    def new_component(form:, repository:, label: nil, hint: nil)
+      # For now all components use the same component for Edit and New. Override
+      # this method in a subclass to provide a different component.
+      edit_component(
+        form: form,
+        hint: hint,
+        label: label,
+        repository: repository
+      )
+    end
+
     # Returns the key that this field is expected to use in params
     def param_key
       name.to_sym

--- a/lib/uchi/field/configuration.rb
+++ b/lib/uchi/field/configuration.rb
@@ -127,7 +127,7 @@ module Uchi
       protected
 
       def default_on
-        [:edit, :index, :show]
+        [:edit, :index, :new, :show]
       end
 
       def default_searchable?

--- a/lib/uchi/repository.rb
+++ b/lib/uchi/repository.rb
@@ -60,6 +60,11 @@ module Uchi
       fields.select { |field| field.on.include?(:index) }.each { |field| field.repository = self }
     end
 
+    # Returns an array of fields to show on the new page.
+    def fields_for_new
+      fields.select { |field| field.on.include?(:new) }.each { |field| field.repository = self }
+    end
+
     # Returns an array of fields to show on the show page.
     def fields_for_show
       fields.select { |field| field.on.include?(:show) }.each { |field| field.repository = self }

--- a/test/components/uchi/field/belongs_to_test.rb
+++ b/test/components/uchi/field/belongs_to_test.rb
@@ -15,7 +15,7 @@ module Uchi
       end
 
       test "has default options" do
-        assert_equal [:edit, :index, :show], @field.on
+        assert_equal [:edit, :index, :new, :show], @field.on
         assert_not @field.searchable?
         assert @field.sortable?
       end
@@ -58,6 +58,16 @@ module Uchi
         assert_equal @form.object, component.record
         assert_equal @repository, component.repository
         assert_kind_of Uchi::Field::BelongsTo::Index, component
+      end
+
+      test "#new_component returns an instance of Edit component" do
+        component = @field.new_component(form: @form, hint: "Custom hint", label: "Custom label", repository: @repository)
+        assert_equal "Custom hint", component.hint
+        assert_equal "Custom label", component.label
+        assert_equal @field, component.field
+        assert_equal @form, component.form
+        assert_equal @repository, component.repository
+        assert_kind_of Uchi::Field::BelongsTo::Edit, component
       end
 
       test "#searchable? returns false when explicitly set" do

--- a/test/components/uchi/field/blank_test.rb
+++ b/test/components/uchi/field/blank_test.rb
@@ -15,7 +15,7 @@ module Uchi
       end
 
       test "has default options" do
-        assert_equal [:edit, :index, :show], @field.on
+        assert_equal [:edit, :index, :new, :show], @field.on
         assert_not @field.searchable?
         assert @field.sortable?
       end

--- a/test/components/uchi/field/boolean_test.rb
+++ b/test/components/uchi/field/boolean_test.rb
@@ -15,7 +15,7 @@ module Uchi
       end
 
       test "has default options" do
-        assert_equal [:edit, :index, :show], @field.on
+        assert_equal [:edit, :index, :new, :show], @field.on
         assert_not @field.searchable?
         assert @field.sortable?
       end

--- a/test/components/uchi/field/date_test.rb
+++ b/test/components/uchi/field/date_test.rb
@@ -15,7 +15,7 @@ module Uchi
       end
 
       test "has default options" do
-        assert_equal [:edit, :index, :show], @field.on
+        assert_equal [:edit, :index, :new, :show], @field.on
         assert_not @field.searchable?
         assert @field.sortable?
       end

--- a/test/components/uchi/field/date_time_test.rb
+++ b/test/components/uchi/field/date_time_test.rb
@@ -15,7 +15,7 @@ module Uchi
       end
 
       test "has default options" do
-        assert_equal [:edit, :index, :show], @field.on
+        assert_equal [:edit, :index, :new, :show], @field.on
         assert_not @field.searchable?
         assert @field.sortable?
       end

--- a/test/components/uchi/field/file_test.rb
+++ b/test/components/uchi/field/file_test.rb
@@ -18,7 +18,7 @@ module Uchi
       end
 
       test "has default options" do
-        assert_equal [:edit, :index, :show], @field.on
+        assert_equal [:edit, :index, :new, :show], @field.on
         assert_not @field.searchable?
         assert_not @field.sortable?
       end

--- a/test/components/uchi/field/image_test.rb
+++ b/test/components/uchi/field/image_test.rb
@@ -18,7 +18,7 @@ module Uchi
       end
 
       test "has default options" do
-        assert_equal [:edit, :index, :show], @field.on
+        assert_equal [:edit, :index, :new, :show], @field.on
         assert_not @field.searchable?
         assert_not @field.sortable?
       end

--- a/test/components/uchi/field/number_test.rb
+++ b/test/components/uchi/field/number_test.rb
@@ -15,7 +15,7 @@ module Uchi
       end
 
       test "has default options" do
-        assert_equal [:edit, :index, :show], @field.on
+        assert_equal [:edit, :index, :new, :show], @field.on
         assert_not @field.searchable?
         assert @field.sortable?
       end

--- a/test/components/uchi/field/string_test.rb
+++ b/test/components/uchi/field/string_test.rb
@@ -15,7 +15,7 @@ module Uchi
       end
 
       test "has default options" do
-        assert_equal [:edit, :index, :show], @field.on
+        assert_equal [:edit, :index, :new, :show], @field.on
         assert @field.searchable?
         assert @field.sortable?
       end

--- a/test/uchi/field_test.rb
+++ b/test/uchi/field_test.rb
@@ -17,7 +17,7 @@ class UchiFieldTest < ActiveSupport::TestCase
   end
 
   test "has default options" do
-    assert_equal [:edit, :index, :show], @field.on
+    assert_equal [:edit, :index, :new, :show], @field.on
     assert_equal true, @field.sortable
   end
 


### PR DESCRIPTION
Previously we'd just default to whatever was on the :edit page, but that doesn't necessarily always work; and at the very least, we shouldn't force it.