### PR TITLE
Exclude polymorphic BelongsTo fields from forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Allow UI to use the full height of the viewport to prevent clipping popovers and dialogs.
+- BelongsTo fields for polymorphic associations no longer cause an error on edit and new pages. Instead, they just don't show up. This isn't exactly optimal, but for now we don't have an automated way of actually figuring out what ActiveRecord class they are associated with.
 
 ### Removed
 

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -144,16 +144,16 @@ The dropdown displays the `title` of the record. For example, a `Person` reposit
 
 ### BelongsTo field for polymorphic associations
 
-Out of the box, `Field::BelongsTo` works for regular `belongs_to` associations as well as polymorphic ones. However, for polymorphic associations the field cannot be shown on `new` pages since Uchi cannot guess what models to show in the associated record dropdown, which causes an exception.
+Out of the box, `Field::BelongsTo` works for regular `belongs_to` associations as well as polymorphic ones. However, for polymorphic associations the field cannot be shown in forms (ie `edit` or `new` pages) since Uchi cannot guess what models to show in the associated record dropdown.
 
-For now, the best workaround is to remove the `BelongsTo` field from `:new` and add explicit fields for the polymorphic attributes instead, ie:
+For now, the best workaround is to remove the `BelongsTo` field from those pages and add explicit fields for the polymorphic attributes instead, ie:
 
 ```ruby
 def fields
   [
-    Field::BelongsTo.new(:owner).on(:edit, :index, :show),
-    Field::String.new(:owner_type).on(:new),
-    Field::Number.new(:owner_id).on(:new),
+    Field::BelongsTo.new(:owner).on(:index, :show),
+    Field::String.new(:owner_type).on(:edit, :new),
+    Field::Number.new(:owner_id).on(:edit, :new),
   ]
 end
 ```

--- a/lib/uchi/repository.rb
+++ b/lib/uchi/repository.rb
@@ -52,22 +52,22 @@ module Uchi
 
     # Returns an array of fields to show on the edit page.
     def fields_for_edit
-      fields.each { |field| field.repository = self }.select { |field| field.on.include?(:edit) }
+      fields_with_repository.select { |field| field.on.include?(:edit) }
     end
 
     # Returns an array of fields to show on the index page.
     def fields_for_index
-      fields.each { |field| field.repository = self }.select { |field| field.on.include?(:index) }
+      fields_with_repository.select { |field| field.on.include?(:index) }
     end
 
     # Returns an array of fields to show on the new page.
     def fields_for_new
-      fields.each { |field| field.repository = self }.select { |field| field.on.include?(:new) }
+      fields_with_repository.select { |field| field.on.include?(:new) }
     end
 
     # Returns an array of fields to show on the show page.
     def fields_for_show
-      fields.each { |field| field.repository = self }.select { |field| field.on.include?(:show) }
+      fields_with_repository.select { |field| field.on.include?(:show) }
     end
 
     def find_all(search: nil, scope: model.all, sort_order: default_sort_order)
@@ -188,6 +188,10 @@ module Uchi
       else
         sort_order.apply(query)
       end
+    end
+
+    def fields_with_repository
+      @fields_with_repository ||= fields.each { |field| field.repository = self }
     end
 
     def searchable_fields

--- a/lib/uchi/repository.rb
+++ b/lib/uchi/repository.rb
@@ -52,22 +52,22 @@ module Uchi
 
     # Returns an array of fields to show on the edit page.
     def fields_for_edit
-      fields.select { |field| field.on.include?(:edit) }.each { |field| field.repository = self }
+      fields.each { |field| field.repository = self }.select { |field| field.on.include?(:edit) }
     end
 
     # Returns an array of fields to show on the index page.
     def fields_for_index
-      fields.select { |field| field.on.include?(:index) }.each { |field| field.repository = self }
+      fields.each { |field| field.repository = self }.select { |field| field.on.include?(:index) }
     end
 
     # Returns an array of fields to show on the new page.
     def fields_for_new
-      fields.select { |field| field.on.include?(:new) }.each { |field| field.repository = self }
+      fields.each { |field| field.repository = self }.select { |field| field.on.include?(:new) }
     end
 
     # Returns an array of fields to show on the show page.
     def fields_for_show
-      fields.select { |field| field.on.include?(:show) }.each { |field| field.repository = self }
+      fields.each { |field| field.repository = self }.select { |field| field.on.include?(:show) }
     end
 
     def find_all(search: nil, scope: model.all, sort_order: default_sort_order)

--- a/lib/uchi/repository.rb
+++ b/lib/uchi/repository.rb
@@ -51,23 +51,31 @@ module Uchi
     end
 
     # Returns an array of fields to show on the edit page.
+    #
+    # @return [Array<Uchi::Field>]
     def fields_for_edit
-      fields_with_repository.select { |field| field.on.include?(:edit) }
+      fields_for(:edit)
     end
 
     # Returns an array of fields to show on the index page.
+    #
+    # @return [Array<Uchi::Field>]
     def fields_for_index
-      fields_with_repository.select { |field| field.on.include?(:index) }
+      fields_for(:index)
     end
 
     # Returns an array of fields to show on the new page.
+    #
+    # @return [Array<Uchi::Field>]
     def fields_for_new
-      fields_with_repository.select { |field| field.on.include?(:new) }
+      fields_for(:new)
     end
 
     # Returns an array of fields to show on the show page.
+    #
+    # @return [Array<Uchi::Field>]
     def fields_for_show
-      fields_with_repository.select { |field| field.on.include?(:show) }
+      fields_for(:show)
     end
 
     def find_all(search: nil, scope: model.all, sort_order: default_sort_order)
@@ -190,8 +198,18 @@ module Uchi
       end
     end
 
+    # Returns an array of fields to show for the given action.
+    #
+    # @param action [Symbol] The action to get fields for. One of :index, :show,
+    # :new, :edit.
+    #
+    # @return [Array<Uchi::Field>]
+    def fields_for(action)
+      fields_with_repository.select { |field| field.on.include?(action) }
+    end
+
     def fields_with_repository
-      @fields_with_repository ||= fields.each { |field| field.repository = self }
+      fields.each { |field| field.repository = self }
     end
 
     def searchable_fields

--- a/test/components/uchi/field/belongs_to_test.rb
+++ b/test/components/uchi/field/belongs_to_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 require "ostruct"
 

--- a/test/components/uchi/field/belongs_to_test.rb
+++ b/test/components/uchi/field/belongs_to_test.rb
@@ -148,6 +148,32 @@ module Uchi
         repo = @component.associated_repository
         assert_kind_of Uchi::Repositories::Book, repo
       end
+
+      test "handles polymorphic associations" do
+        # Create an ActiveStorage::Attachment which has a polymorphic belongs_to :record
+        book = Book.create!(original_title: "Test Book")
+        book.samples.attach(io: StringIO.new("fake image data"), filename: "sample.jpg")
+        attachment = book.samples.attachments.first
+
+        field = Uchi::Field::BelongsTo.new(:record)
+        repository = Uchi::Repositories::Title.new
+        view_context = ActionController::Base.new.view_context
+        form = ActionView::Helpers::FormBuilder.new(:active_storage_attachment, attachment, view_context, {})
+
+        component = Uchi::Field::BelongsTo::Edit.new(
+          field: field,
+          form: form,
+          hint: "Record hint",
+          label: "Record label",
+          repository: repository
+        )
+
+        # This should not raise "Polymorphic associations do not support computing the class"
+        error = assert_raises(ArgumentError) do
+          component.associated_repository
+        end
+        assert_match(/Polymorphic associations do not support computing the class/, error.message)
+      end
     end
 
     class BelongsToIndexTest < ViewComponent::TestCase
@@ -216,6 +242,28 @@ module Uchi
           component.associated_repository
         end
         assert_match(/No association named :nonexistent_association found/, error.message)
+      end
+
+      test "handles polymorphic associations" do
+        # Create an ActiveStorage::Attachment which has a polymorphic belongs_to :record
+        book = Book.create!(original_title: "Test Book")
+        book.samples.attach(io: StringIO.new("fake image data"), filename: "sample.jpg")
+        attachment = book.samples.attachments.first
+
+        field = Uchi::Field::BelongsTo.new(:record)
+        repository = Uchi::Repositories::Title.new
+
+        component = Uchi::Field::BelongsTo::Index.new(
+          field: field,
+          record: attachment,
+          repository: repository
+        )
+
+        # This should not raise "Polymorphic associations do not support computing the class"
+        error = assert_raises(ArgumentError) do
+          component.associated_repository
+        end
+        assert_match(/Polymorphic associations do not support computing the class/, error.message)
       end
     end
 
@@ -290,6 +338,28 @@ module Uchi
           component.associated_repository
         end
         assert_match(/No association named :nonexistent_association found/, error.message)
+      end
+
+      test "handles polymorphic associations" do
+        # Create an ActiveStorage::Attachment which has a polymorphic belongs_to :record
+        book = Book.create!(original_title: "Test Book")
+        book.samples.attach(io: StringIO.new("fake image data"), filename: "sample.jpg")
+        attachment = book.samples.attachments.first
+
+        field = Uchi::Field::BelongsTo.new(:record)
+        repository = Uchi::Repositories::Title.new
+
+        component = Uchi::Field::BelongsTo::Show.new(
+          field: field,
+          record: attachment,
+          repository: repository
+        )
+
+        # This should not raise "Polymorphic associations do not support computing the class"
+        error = assert_raises(ArgumentError) do
+          component.associated_repository
+        end
+        assert_match(/Polymorphic associations do not support computing the class/, error.message)
       end
     end
   end

--- a/test/components/uchi/field/file_test.rb
+++ b/test/components/uchi/field/file_test.rb
@@ -7,8 +7,8 @@ module Uchi
   class Field
     class FileTest < ActiveSupport::TestCase
       def setup
-        @book = Book.new(sample: nil)
-        @field = Uchi::Field::File.new(:sample)
+        @book = Book.new(cover: nil)
+        @field = Uchi::Field::File.new(:cover)
         @form = OpenStruct.new(object: @book)
         @repository = Uchi::Repositories::Book.new
       end
@@ -60,8 +60,8 @@ module Uchi
 
     class FileEditTest < ViewComponent::TestCase
       def setup
-        @field = Uchi::Field::File.new(:sample)
-        @record = Book.new(sample: nil)
+        @field = Uchi::Field::File.new(:cover)
+        @record = Book.new(cover: nil)
         @repository = Uchi::Repositories::Book.new
         @view_context = ActionController::Base.new.view_context
 
@@ -83,24 +83,24 @@ module Uchi
       test "renders a file input field" do
         render_inline(@component)
 
-        assert_selector("input[type='file'][name='book[sample]']")
+        assert_selector("input[type='file'][name='book[cover]']")
       end
 
       test "renders label with specified text" do
         render_inline(@component)
 
-        assert_selector("label[for='book_sample']", text: "Custom label")
+        assert_selector("label[for='book_cover']", text: "Custom label")
       end
 
       test "renders hint when provided" do
         render_inline(@component)
 
-        assert_selector("p[id=book_sample_hint]", text: "Custom hint")
+        assert_selector("p[id=book_cover_hint]", text: "Custom hint")
       end
 
       test "initializes the input component with the correct options" do
         expected_options = {
-          attribute: :sample,
+          attribute: :cover,
           form: @form,
           label: {content: "Custom label"},
           hint: {content: "Custom hint"}
@@ -111,7 +111,7 @@ module Uchi
 
     class FileIndexTest < ViewComponent::TestCase
       def setup
-        @field = Uchi::Field::File.new(:sample)
+        @field = Uchi::Field::File.new(:cover)
         @record = Book.new
         @repository = Uchi::Repositories::Book.new
 
@@ -135,7 +135,7 @@ module Uchi
       test "renders filename when file is attached" do
         # Create a record with an attached file
         file = ::File.open(Rails.root.join("test/fixtures/files/pdf.pdf"))
-        @record = Book.new(sample: file)
+        @record = Book.new(cover: file)
 
         @component = Uchi::Field::File::Index.new(
           field: @field,
@@ -151,9 +151,9 @@ module Uchi
 
     class FileShowTest < ViewComponent::TestCase
       def setup
-        @field = Uchi::Field::File.new(:sample)
+        @field = Uchi::Field::File.new(:cover)
         file = ::File.open(Rails.root.join("test/fixtures/files/pdf.pdf"))
-        @record = Book.create!(sample: file)
+        @record = Book.create!(cover: file)
         @repository = Uchi::Repositories::Book.new
 
         @component = Uchi::Field::File::Show.new(
@@ -168,7 +168,7 @@ module Uchi
       end
 
       test "renders a dash when no file is attached" do
-        @record.sample.detach
+        @record.cover.detach
 
         result = render_inline(@component)
 

--- a/test/dummy/app/models/book.rb
+++ b/test/dummy/app/models/book.rb
@@ -2,6 +2,6 @@ class Book < ApplicationRecord
   has_and_belongs_to_many :authors
   has_many :titles
 
-  has_one_attached :sample
+  has_many_attached :samples
   has_one_attached :cover
 end


### PR DESCRIPTION
Depends on #81 

Rendering an input widget for a polymorphic `BelongsTo` field isn't as straightforward as for other fields.

The core reason is the fact that we don't know in advance which model the record is associated with. Sure, when editing an existing record we can tell the model by looking at the currently associated record, but there's no guarantee that the user won't want to change the association to a different model.

For new records, the problem is even more pronounced, as there's no associated record at all yet, so we can't even guess the model.

Until we have a proper solution for this, we'll exclude polymorphic `BelongsTo` fields from edit and new forms, to avoid confusing errors.

Client code can set `on(:new, :edit)` and still include the generic UI, however it is likely to cause an error like:

> Polymorphic associations do not support computing the class.

For now, the best workaround is to add explicit fields for the polymorphic attributes instead, ie:

```
def fields
  [
    Field::BelongsTo.new(:owner),
    Field::String.new(:owner_type).on(:new),
    Field::Number.new(:owner_id).on(:new),
  ]
end
```
