### PR TITLE
Clean up Javascript dependencies

### DIFF
--- a/.herb.yml
+++ b/.herb.yml
@@ -1,0 +1,21 @@
+version: 0.8.7
+files:
+  include:
+    - "**/*.html"
+    - "**/*.rhtml"
+    - "**/*.html.erb"
+    - "**/*.html+*.erb"
+    - "**/*.turbo_stream.erb"
+  exclude:
+    - node_modules/**/*
+    - vendor/bundle/**/*
+    - coverage/**/*
+
+linter:
+  enabled: true
+  rules: {}
+
+formatter:
+  enabled: true
+  indentWidth: 2
+  maxLineLength: 80

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@rails/request.js": "^0.0.13",
     "@stimulus-components/dropdown": "^3.0.0",
     "@tailwindcss/cli": "^4.1.13",
-    "esbuild": "0.27.2",
+    "esbuild": "^0.27.2",
     "flowbite": "^4.0.1",
     "tailwindcss": "^4.1.13"
   }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,5 @@
 {
   "name": "uchi",
-  "version": "0.0.1",
-  "description": "## Installation",
-  "main": "index.js",
   "directories": {
     "lib": "lib",
     "test": "test"
@@ -16,7 +13,6 @@
     "watch:css": "node_modules/.bin/tailwindcss --watch -i ./app/assets/tailwind/uchi.css -o ./app/assets/stylesheets/uchi/application.css",
     "watch:js": "node_modules/.bin/esbuild --watch --bundle --outfile=app/assets/javascripts/uchi/application.js app/assets/javascripts/uchi.js"
   },
-  "author": "",
   "license": "ISC",
   "devDependencies": {
     "@github/combobox-nav": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -18,17 +18,15 @@
   },
   "author": "",
   "license": "ISC",
-  "dependencies": {
+  "devDependencies": {
     "@github/combobox-nav": "^3.0.1",
+    "@herb-tools/linter": "^0.8.2",
     "@hotwired/turbo-rails": "^8.0.16",
     "@rails/request.js": "^0.0.13",
     "@stimulus-components/dropdown": "^3.0.0",
     "@tailwindcss/cli": "^4.1.13",
+    "esbuild": "0.27.2",
     "flowbite": "^4.0.1",
     "tailwindcss": "^4.1.13"
-  },
-  "devDependencies": {
-    "@herb-tools/linter": "^0.8.2",
-    "esbuild": "0.27.2"
   }
 }


### PR DESCRIPTION
We use a few Javascript dependencies for Uchi's frontend interactivity and while they aren't strictly dependencies for Uchi to work, we need them to generate the CSS and JS that Uchi does need to work.