### PR TITLE
Add option to mount at a custom path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Fields can now be configured to appear on :new pages, but not on :edit, and vice versa. Either add or remove `:new` from the fields `on()` configuration as needed.
+- Uchi can now be mounted at a path other than /uchi. If you want it to live at fx. /admin, use the `at:` argument: `Uchi.routes.mount(self, at: :admin)`.
 
 ### Fixed
 

--- a/app/components/uchi/field/belongs_to/edit.html.erb
+++ b/app/components/uchi/field/belongs_to/edit.html.erb
@@ -2,7 +2,7 @@
   class="relative"
   data-action="keydown.esc->belongs-to#closeDropdown"
   data-controller="belongs-to"
-  data-belongs-to-backend-url-value="<%= helpers.belongs_to_associated_records_path(field: field.name, model: repository.model, record_id: record&.id) %>"
+  data-belongs-to-backend-url-value="<%= helpers.uchi.belongs_to_associated_records_path(field: field.name, model: repository.model, record_id: record&.id) %>"
 >
   <%= render(Uchi::Flowbite::Input::Label.new(attribute: field.name, form: form, options: {for: dom_id_for_toggle})) { label } %>
 

--- a/app/components/uchi/field/has_many/edit.html.erb
+++ b/app/components/uchi/field/has_many/edit.html.erb
@@ -2,7 +2,7 @@
   class="relative"
   data-action="keydown.esc->has-many#closeDropdown"
   data-controller="has-many"
-  data-has-many-backend-url-value="<%= helpers.has_many_associated_records_path(field: field.name, model: repository.model, record_id: record&.id) %>"
+  data-has-many-backend-url-value="<%= helpers.uchi.has_many_associated_records_path(field: field.name, model: repository.model, record_id: record&.id) %>"
   data-has-many-field-name-value="<%= field_name_for_input %>"
 >
   <%= render(Uchi::Flowbite::Input::Label.new(attribute: field.name, form: form, options: {for: dom_id_for_toggle})) { label } %>

--- a/app/components/uchi/ui/actions/dropdown/dropdown.html.erb
+++ b/app/components/uchi/ui/actions/dropdown/dropdown.html.erb
@@ -42,7 +42,7 @@
     >
       <% actions.each do |action| %>
         <li role="menuitem">
-          <%= form_with url: helpers.actions_executions_path, method: :post, class: "block" do %>
+          <%= form_with url: helpers.uchi.actions_executions_path, method: :post, class: "block" do %>
             <%= hidden_field_tag :model, repository.model.name %>
             <%= hidden_field_tag :action_name, action.class.name %>
             <%= hidden_field_tag :id, record.id %>

--- a/lib/uchi/repository/routes.rb
+++ b/lib/uchi/repository/routes.rb
@@ -22,7 +22,7 @@ module Uchi
       end
 
       def root_path
-        "/#{uchi_namespace}/"
+        "/#{uchi_path}/"
       end
 
       private
@@ -34,7 +34,7 @@ module Uchi
 
       def plural_path_for(_action, **options)
         parts = [
-          uchi_namespace,
+          uchi_as,
           plural,
           "path"
         ].compact
@@ -47,15 +47,19 @@ module Uchi
         action = nil if action == :destroy
         parts = [
           action,
-          uchi_namespace,
+          uchi_as,
           singular,
           "path"
         ].compact
         call_url_helper_in_main_app(parts, **options)
       end
 
-      def uchi_namespace
-        :uchi
+      def uchi_as
+        Uchi.routes.mount_as
+      end
+
+      def uchi_path
+        Uchi.routes.mount_at
       end
     end
   end

--- a/lib/uchi/routes.rb
+++ b/lib/uchi/routes.rb
@@ -7,19 +7,26 @@ module Uchi
     #  Rails.application.routes.draw do
     #    Uchi.routes.mount(self)
     #  end
+    #
+    # @param host_routes [ActionDispatch::Routing::Mapper] The host
+    # application's routes mapper.
+    #
+    # @param at [Symbol] The path segment where Uchi should be mounted.
     def mount(host_routes, at: default_at)
+      @mount_at = at.to_sym
       host_routes.mount(
         Uchi::Engine,
-        at: at
+        as: mount_as,
+        at: mount_at
       )
 
-      draw_repository_routes(host_routes, at: at)
+      draw_repository_routes(host_routes, at: mount_at)
     end
 
     def draw_root_route(routes, repository:, at: default_at)
       return unless repository
 
-      routes.namespace(at) do
+      routes.namespace(at, as: mount_as) do
         routes.root to: "#{repository.controller_name}#index"
       end
     end
@@ -28,7 +35,7 @@ module Uchi
       repositories = Uchi::Repository.all
       repositories.each do |repository_class|
         resources_name = repository_class.controller_name
-        routes.namespace(at) do
+        routes.namespace(at, as: mount_as) do
           routes.resources(resources_name)
         end
       end
@@ -36,10 +43,25 @@ module Uchi
       draw_root_route(routes, at: at, repository: repositories.first)
     end
 
+    # Returns the name to use when generating routing helper method names
+    def mount_as
+      :uchi
+    end
+
+    # Returns the path prefix for the routes, i.e. the first URL segment where
+    # Uchi can be requested.
+    def mount_at
+      @mount_at ||= default_at
+    end
+
     private
 
     def default_at
-      "uchi"
+      :uchi
+    end
+
+    def mount_path
+      mount_at
     end
   end
 end

--- a/lib/uchi/routes.rb
+++ b/lib/uchi/routes.rb
@@ -13,7 +13,7 @@ module Uchi
     #
     # @param at [Symbol] The path segment where Uchi should be mounted.
     def mount(host_routes, at: default_at)
-      @mount_at = at.to_sym
+      @mount_at = (at || default_at).to_sym
       host_routes.mount(
         Uchi::Engine,
         as: mount_as,

--- a/test/support/mount_helper.rb
+++ b/test/support/mount_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module MountHelper
+  def when_mounted(at: :uchi)
+    original_mount_at = Uchi.routes.instance_variable_get(:@mount_at)
+    begin
+      Uchi.routes.instance_variable_set(:@mount_at, at)
+
+      yield
+    ensure
+      # Restore original mount path
+      Uchi.routes.instance_variable_set(:@mount_at, original_mount_at)
+    end
+  end
+end

--- a/test/uchi/repository/routes_test.rb
+++ b/test/uchi/repository/routes_test.rb
@@ -1,7 +1,10 @@
 require "test_helper"
+require "support/mount_helper"
 require_relative "../../dummy/app/uchi/repositories/author"
 
 class UchiRepositoryRoutesTest < ActiveSupport::TestCase
+  include MountHelper
+
   def setup
     @repository = Uchi::Repositories::Author.new
     @routes = @repository.routes
@@ -52,60 +55,29 @@ class UchiRepositoryRoutesTest < ActiveSupport::TestCase
   end
 
   test "#root_path respects custom mount path" do
-    # Simulate mounting at a custom path
-    original_mount_at = Uchi.routes.instance_variable_get(:@mount_at)
-    begin
-      Uchi.routes.instance_variable_set(:@mount_at, :admin)
+    when_mounted(at: :admin) do
       repository = Uchi::Repositories::Author.new
       routes = repository.routes
 
       assert_equal "/admin/", routes.root_path
-    ensure
-      # Restore original mount path
-      if original_mount_at
-        Uchi.routes.instance_variable_set(:@mount_at, original_mount_at)
-      else
-        Uchi.routes.instance_variable_set(:@mount_at, nil)
-      end
     end
   end
 
   test "uchi_path uses mount_at when set" do
-    original_mount_path = Uchi.routes.instance_variable_get(:@mount_at)
-    begin
-      Uchi.routes.instance_variable_set(:@mount_at, :admin)
-
+    when_mounted(at: :admin) do
       repository = Uchi::Repositories::Author.new
       routes = repository.routes
 
       assert_equal :admin, routes.send(:uchi_path)
-    ensure
-      # Restore original mount path
-      if original_mount_path
-        Uchi.routes.instance_variable_set(:@mount_at, original_mount_path)
-      else
-        Uchi.routes.instance_variable_set(:@mount_at, nil)
-      end
     end
   end
 
   test "uchi_path defaults to :uchi when mount_at is not set" do
-    # Ensure mount_path is not set
-    original_mount_at = Uchi.routes.instance_variable_get(:@mount_at)
-    begin
-      Uchi.routes.instance_variable_set(:@mount_at, nil)
-
+    when_mounted(at: nil) do
       repository = Uchi::Repositories::Author.new
       routes = repository.routes
 
       assert_equal :uchi, routes.send(:uchi_path)
-    ensure
-      # Restore original mount path
-      if original_mount_at
-        Uchi.routes.instance_variable_set(:@mount_at, original_mount_at)
-      else
-        Uchi.routes.instance_variable_set(:@mount_at, nil)
-      end
     end
   end
 end

--- a/test/uchi/repository/routes_test.rb
+++ b/test/uchi/repository/routes_test.rb
@@ -46,4 +46,66 @@ class UchiRepositoryRoutesTest < ActiveSupport::TestCase
   test "#path_for returns path to update action" do
     assert_equal "/uchi/authors/1", @routes.path_for(:update, id: 1)
   end
+
+  test "#root_path returns the root path with default mount" do
+    assert_equal "/uchi/", @routes.root_path
+  end
+
+  test "#root_path respects custom mount path" do
+    # Simulate mounting at a custom path
+    original_mount_at = Uchi.routes.instance_variable_get(:@mount_at)
+    begin
+      Uchi.routes.instance_variable_set(:@mount_at, :admin)
+      repository = Uchi::Repositories::Author.new
+      routes = repository.routes
+
+      assert_equal "/admin/", routes.root_path
+    ensure
+      # Restore original mount path
+      if original_mount_at
+        Uchi.routes.instance_variable_set(:@mount_at, original_mount_at)
+      else
+        Uchi.routes.instance_variable_set(:@mount_at, nil)
+      end
+    end
+  end
+
+  test "uchi_path uses mount_at when set" do
+    original_mount_path = Uchi.routes.instance_variable_get(:@mount_at)
+    begin
+      Uchi.routes.instance_variable_set(:@mount_at, :admin)
+
+      repository = Uchi::Repositories::Author.new
+      routes = repository.routes
+
+      assert_equal :admin, routes.send(:uchi_path)
+    ensure
+      # Restore original mount path
+      if original_mount_path
+        Uchi.routes.instance_variable_set(:@mount_at, original_mount_path)
+      else
+        Uchi.routes.instance_variable_set(:@mount_at, nil)
+      end
+    end
+  end
+
+  test "uchi_path defaults to :uchi when mount_at is not set" do
+    # Ensure mount_path is not set
+    original_mount_at = Uchi.routes.instance_variable_get(:@mount_at)
+    begin
+      Uchi.routes.instance_variable_set(:@mount_at, nil)
+
+      repository = Uchi::Repositories::Author.new
+      routes = repository.routes
+
+      assert_equal :uchi, routes.send(:uchi_path)
+    ensure
+      # Restore original mount path
+      if original_mount_at
+        Uchi.routes.instance_variable_set(:@mount_at, original_mount_at)
+      else
+        Uchi.routes.instance_variable_set(:@mount_at, nil)
+      end
+    end
+  end
 end


### PR DESCRIPTION
With this Uchi can now be mounted at a path other than the default `/uchi` path.

If you want it to live at fx. `/admin`, use the `at:` argument:

    Uchi.routes.mount(self, at: "admin")

The namespace for all Uchi controllers is still expected to be `Uchi`, and routes helpers are still prefixed with `uchi_`, regardless of the mount path.