### PR TITLE
Add plugin setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fields can now be configured to appear on :new pages, but not on :edit, and vice versa. Either add or remove `:new` from the fields `on()` configuration as needed.
 - Uchi can now be mounted at a path other than /uchi. If you want it to live at fx. /admin, use the `at:` argument: `Uchi.routes.mount(self, at: :admin)`.
+- Inklings of a plugin-system. For now, it's for internal use only.
 
 ### Fixed
 

--- a/lib/uchi.rb
+++ b/lib/uchi.rb
@@ -11,12 +11,17 @@ require "uchi/action"
 require "uchi/action_response"
 require "uchi/field"
 require "uchi/i18n"
+require "uchi/plugins"
 require "uchi/repository"
 require "uchi/routes"
 require "uchi/sort_order"
 require "uchi/repository/translate"
 
 module Uchi
+  def self.plugins
+    @plugins ||= Plugins.new
+  end
+
   def self.routes
     @routes ||= Routes.new
   end

--- a/lib/uchi/plugins.rb
+++ b/lib/uchi/plugins.rb
@@ -1,0 +1,21 @@
+module Uchi
+  class Plugins
+    attr_reader :registered
+
+    def hook(hook_name, **kwargs)
+      registered.each do |plugin_class|
+        next unless plugin_class.hooks_into?(hook_name)
+
+        plugin_class.hook(hook_name, **kwargs)
+      end
+    end
+
+    def initialize
+      @registered = []
+    end
+
+    def register(plugin_class)
+      @registered << plugin_class
+    end
+  end
+end


### PR DESCRIPTION
For now this is mostly a placeholder for internal use, but it will eventually be documented and made available for external use as well. The idea is to have a simple way for plugins to hook into various parts of Uchi's codebase.