### PR TITLE
Add `visible` configuration option to fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Uchi can now be mounted at a path other than /uchi. If you want it to live at fx. /admin, use the `at:` argument: `Uchi.routes.mount(self, at: :admin)`.
 - Inklings of a plugin-system. For now, it's for internal use only.
 - A bunch of documentation with more to come.
+- Add `visible` configuration option to fields. This gives finer control over which fields are displayed for a given record, allowing for more dynamic and context-sensitive UIs.
 
 ### Fixed
 

--- a/app/controllers/uchi/repository_controller.rb
+++ b/app/controllers/uchi/repository_controller.rb
@@ -133,7 +133,7 @@ module Uchi
     end
 
     def permitted_params_for_new
-      @repository.fields_for_new(record: @record).map(&:permitted_param)
+      @repository.fields_for_new(record: @record || @repository.build).map(&:permitted_param)
     end
 
     def record_params_for_edit

--- a/app/controllers/uchi/repository_controller.rb
+++ b/app/controllers/uchi/repository_controller.rb
@@ -129,11 +129,11 @@ module Uchi
     end
 
     def permitted_params_for_edit
-      @repository.fields_for_edit.map(&:permitted_param)
+      @repository.fields_for_edit(record: @record).map(&:permitted_param)
     end
 
     def permitted_params_for_new
-      @repository.fields_for_new.map(&:permitted_param)
+      @repository.fields_for_new(record: @record).map(&:permitted_param)
     end
 
     def record_params_for_edit

--- a/app/views/uchi/repository/edit.html.erb
+++ b/app/views/uchi/repository/edit.html.erb
@@ -17,7 +17,7 @@
   <%= render(Uchi::Flowbite::Card.new) do %>
     <%= form_with model: @record, url: @repository.routes.path_for(:update, id: @record.id) do |form| %>
       <div class="space-y-6">
-        <% @repository.fields_for_edit.each do |field| %>
+        <% @repository.fields_for_edit(record: @record).each do |field| %>
           <div>
             <%= render(
               field.edit_component(

--- a/app/views/uchi/repository/new.html.erb
+++ b/app/views/uchi/repository/new.html.erb
@@ -15,7 +15,7 @@
 <%= render(Uchi::Flowbite::Card.new) do %>
   <%= form_with model: @record, url: @repository.routes.path_for(:create) do |form| %>
     <div class="space-y-6">
-      <% @repository.fields_for_new.each do |field| %>
+      <% @repository.fields_for_new(record: @record).each do |field| %>
         <div>
           <%= render(
             field.new_component(

--- a/app/views/uchi/repository/show.html.erb
+++ b/app/views/uchi/repository/show.html.erb
@@ -39,14 +39,14 @@
     ]) %>
 <% end %>
 
+<% visible_fields = @repository.fields_for_show.select { |field| field.visible_for?(@record) } %>
+
 <%= render(Uchi::Ui::Show::AttributeFields.new(
-  attribute_fields: @repository.fields_for_show.select { |field| field.group_as(:show) == :attributes && field.visible_for?(@record) },
+  attribute_fields: visible_fields.select { |field| field.group_as(:show) == :attributes },
   record: @record,
   repository: @repository
 )) %>
 
-<% association_fields = @repository.fields_for_show.select { |field| field.group_as(:show) == :associations && field.visible_for?(@record) } %>
-
-<% association_fields.each do |field| %>
+<% visible_fields.select { |field| field.group_as(:show) == :associations }.each do |field| %>
   <%= render(field.show_component(record: @record, repository: @repository)) %>
 <% end %>

--- a/app/views/uchi/repository/show.html.erb
+++ b/app/views/uchi/repository/show.html.erb
@@ -39,7 +39,7 @@
     ]) %>
 <% end %>
 
-<% visible_fields = @repository.fields_for_show.select { |field| field.visible_for?(@record) } %>
+<% visible_fields = @repository.fields_for_show(record: @record) %>
 
 <%= render(Uchi::Ui::Show::AttributeFields.new(
   attribute_fields: visible_fields.select { |field| field.group_as(:show) == :attributes },

--- a/app/views/uchi/repository/show.html.erb
+++ b/app/views/uchi/repository/show.html.erb
@@ -40,12 +40,12 @@
 <% end %>
 
 <%= render(Uchi::Ui::Show::AttributeFields.new(
-  attribute_fields: @repository.fields_for_show.select { |field| field.group_as(:show) == :attributes },
+  attribute_fields: @repository.fields_for_show.select { |field| field.group_as(:show) == :attributes && field.visible_for?(@record) },
   record: @record,
   repository: @repository
 )) %>
 
-<% association_fields = @repository.fields_for_show.select{ |field| field.group_as(:show) == :associations } %>
+<% association_fields = @repository.fields_for_show.select { |field| field.group_as(:show) == :associations && field.visible_for?(@record) } %>
 
 <% association_fields.each do |field| %>
   <%= render(field.show_component(record: @record, repository: @repository)) %>

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -1,6 +1,8 @@
 # Fields
 
-## Only show a field on specific pages
+## Visibility
+
+### Only show a field on specific pages
 
 Use the `on` method to control what pages to show a field on. For example if your id field should only be visible on the index listing, you can configure it as
 
@@ -16,6 +18,16 @@ Possible actions are
 - `:edit`
 
 The default is to show all fields on all pages.
+
+### Only show a field for specific records
+
+Giving the field a `visible` lambda gives you more control over when to render a field.
+
+```ruby
+Field::Number.new(:discount).visible(->(record) { record.discountable? })
+```
+
+The lambda is passed the actual record and the field will be rendered if the lambda returns a truthy value.
 
 ## Search
 

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -29,6 +29,8 @@ Field::Number.new(:discount).visible(->(record) { record.discountable? })
 
 The lambda is passed the actual record and the field will be rendered if the lambda returns a truthy value.
 
+Note that this is not usable for index pages. The index table header always shows all configured columns — since there's no single record to evaluate visibility against. To remove a column from the index page use `on([:edit, :new, :show])` instead.
+
 ## Search
 
 If a repository contains at least one searchable `Field` a search field appears on the index page. By default all text-based fields are considered searchable.

--- a/lib/uchi/field/configuration.rb
+++ b/lib/uchi/field/configuration.rb
@@ -12,6 +12,7 @@ module Uchi
         @on = default_on
         @reader = DEFAULT_READER
         @searchable = default_searchable?
+        @visible = nil
         @sortable = default_sortable?
       end
 
@@ -89,6 +90,29 @@ module Uchi
         !!@searchable
       end
 
+      # Sets or gets a conditional proc that determines whether this field should
+      # be visible for a given record.
+      #
+      # When called with a proc argument, sets the visibility condition and returns
+      # self for chaining. When called without arguments, returns the current proc.
+      #
+      # @param visible_proc [Proc, nil] A callable that receives the record and returns
+      #   a boolean indicating whether the field should be visible.
+      # @return [self, Proc, nil] Returns self for method chaining when setting,
+      #   or the proc (or nil) when getting
+      #
+      # @example Setting
+      #   Field::String.new(:id).visible(lambda { |record| record.id.even? })
+      #
+      # @example Getting
+      #   field.visible # => #<Proc...>
+      def visible(visible_proc = nil)
+        return @visible if visible_proc.nil?
+
+        @visible = visible_proc
+        self
+      end
+
       # Sets or gets whether and how this field is sortable.
       #
       # When called with an argument, sets sortable and returns self for chaining.
@@ -122,6 +146,20 @@ module Uchi
         return default_sortable? if @sortable.nil?
 
         !!@sortable
+      end
+
+      # Returns whether this field should be visible for the given record.
+      #
+      # When no visible proc is configured, this always returns true.
+      # When a visible proc is configured, it is called with the record and its
+      # return value determines visibility.
+      #
+      # @param record [Object] The record to check visibility for
+      # @return [Boolean] Whether the field should be visible
+      def visible_for?(record)
+        return true if @visible.nil?
+
+        @visible.call(record)
       end
 
       protected

--- a/lib/uchi/field/configuration.rb
+++ b/lib/uchi/field/configuration.rb
@@ -158,7 +158,7 @@ module Uchi
       # @param record [Object] The record to check visibility for
       # @return [Boolean] Whether the field should be visible
       def visible_for?(record)
-        @visible.call(record)
+        !!@visible.call(record)
       end
 
       protected

--- a/lib/uchi/field/configuration.rb
+++ b/lib/uchi/field/configuration.rb
@@ -6,13 +6,14 @@ module Uchi
       class Unset; end
 
       DEFAULT_READER = ->(record, field_name) { record&.public_send(field_name) }
+      DEFAULT_VISIBLE = ->(_record) { true }
 
       def initialize(*args)
         super
         @on = default_on
         @reader = DEFAULT_READER
         @searchable = default_searchable?
-        @visible = nil
+        @visible = DEFAULT_VISIBLE
         @sortable = default_sortable?
       end
 
@@ -106,8 +107,8 @@ module Uchi
       #
       # @example Getting
       #   field.visible # => #<Proc...>
-      def visible(visible_proc = nil)
-        return @visible if visible_proc.nil?
+      def visible(visible_proc = Configuration::Unset)
+        return @visible if visible_proc == Configuration::Unset
 
         @visible = visible_proc
         self
@@ -157,8 +158,6 @@ module Uchi
       # @param record [Object] The record to check visibility for
       # @return [Boolean] Whether the field should be visible
       def visible_for?(record)
-        return true if @visible.nil?
-
         @visible.call(record)
       end
 

--- a/lib/uchi/field/configuration.rb
+++ b/lib/uchi/field/configuration.rb
@@ -97,10 +97,11 @@ module Uchi
       # When called with a proc argument, sets the visibility condition and returns
       # self for chaining. When called without arguments, returns the current proc.
       #
-      # @param visible_proc [Proc, nil] A callable that receives the record and returns
+      # @param visible_proc [Proc] A callable that receives the record and returns
       #   a boolean indicating whether the field should be visible.
-      # @return [self, Proc, nil] Returns self for method chaining when setting,
-      #   or the proc (or nil) when getting
+      #   Raises ArgumentError for non-callables.
+      # @return [self, Proc] Returns self for method chaining when setting,
+      #   or the current proc when getting
       #
       # @example Setting
       #   Field::String.new(:id).visible(lambda { |record| record.id.even? })
@@ -109,6 +110,8 @@ module Uchi
       #   field.visible # => #<Proc...>
       def visible(visible_proc = Configuration::Unset)
         return @visible if visible_proc == Configuration::Unset
+
+        raise ArgumentError, "visible must be callable" unless visible_proc.respond_to?(:call)
 
         @visible = visible_proc
         self
@@ -151,9 +154,8 @@ module Uchi
 
       # Returns whether this field should be visible for the given record.
       #
-      # When no visible proc is configured, this always returns true.
-      # When a visible proc is configured, it is called with the record and its
-      # return value determines visibility.
+      # Calls the visible proc with the record. Defaults to DEFAULT_VISIBLE,
+      # which always returns true.
       #
       # @param record [Object] The record to check visibility for
       # @return [Boolean] Whether the field should be visible

--- a/lib/uchi/repository.rb
+++ b/lib/uchi/repository.rb
@@ -52,9 +52,10 @@ module Uchi
 
     # Returns an array of fields to show on the edit page.
     #
+    # @param record [Object] The record being edited, used to evaluate field visibility.
     # @return [Array<Uchi::Field>]
-    def fields_for_edit
-      fields_for(:edit)
+    def fields_for_edit(record:)
+      fields_for(:edit).select { |field| field.visible_for?(record) }
     end
 
     # Returns an array of fields to show on the index page.
@@ -66,9 +67,10 @@ module Uchi
 
     # Returns an array of fields to show on the new page.
     #
+    # @param record [Object] The record being created, used to evaluate field visibility.
     # @return [Array<Uchi::Field>]
-    def fields_for_new
-      fields_for(:new)
+    def fields_for_new(record:)
+      fields_for(:new).select { |field| field.visible_for?(record) }
     end
 
     # Returns an array of fields to show on the show page.

--- a/lib/uchi/repository.rb
+++ b/lib/uchi/repository.rb
@@ -75,9 +75,10 @@ module Uchi
 
     # Returns an array of fields to show on the show page.
     #
+    # @param record [Object] The record being shown, used to evaluate field visibility.
     # @return [Array<Uchi::Field>]
-    def fields_for_show
-      fields_for(:show)
+    def fields_for_show(record:)
+      fields_for(:show).select { |field| field.visible_for?(record) }
     end
 
     def find_all(search: nil, scope: model.all, sort_order: default_sort_order)

--- a/lib/uchi/repository.rb
+++ b/lib/uchi/repository.rb
@@ -52,9 +52,12 @@ module Uchi
 
     # Returns an array of fields to show on the edit page.
     #
-    # @param record [Object] The record being edited, used to evaluate field visibility.
+    # @param record [Object, nil] The record being edited. When provided, fields with a
+    #   visibility condition are filtered by it. When omitted, all edit fields are returned.
     # @return [Array<Uchi::Field>]
-    def fields_for_edit(record:)
+    def fields_for_edit(record: nil)
+      return fields_for(:edit) if record.nil?
+
       fields_for(:edit).select { |field| field.visible_for?(record) }
     end
 
@@ -67,17 +70,23 @@ module Uchi
 
     # Returns an array of fields to show on the new page.
     #
-    # @param record [Object] The record being created, used to evaluate field visibility.
+    # @param record [Object, nil] The record being created. When provided, fields with a
+    #   visibility condition are filtered by it. When omitted, all new fields are returned.
     # @return [Array<Uchi::Field>]
-    def fields_for_new(record:)
+    def fields_for_new(record: nil)
+      return fields_for(:new) if record.nil?
+
       fields_for(:new).select { |field| field.visible_for?(record) }
     end
 
     # Returns an array of fields to show on the show page.
     #
-    # @param record [Object] The record being shown, used to evaluate field visibility.
+    # @param record [Object, nil] The record being shown. When provided, fields with a
+    #   visibility condition are filtered by it. When omitted, all show fields are returned.
     # @return [Array<Uchi::Field>]
-    def fields_for_show(record:)
+    def fields_for_show(record: nil)
+      return fields_for(:show) if record.nil?
+
       fields_for(:show).select { |field| field.visible_for?(record) }
     end
 

--- a/test/uchi/field_test.rb
+++ b/test/uchi/field_test.rb
@@ -74,4 +74,34 @@ class UchiFieldTest < ActiveSupport::TestCase
 
     assert_equal "Custom: Test", field.value(record)
   end
+
+  test "#visible returns nil by default" do
+    assert_nil @field.visible
+  end
+
+  test "#visible sets a proc and returns self for chaining" do
+    proc = ->(record) { record.id.even? }
+    result = @field.visible(proc)
+
+    assert_equal @field, result
+    assert_equal proc, @field.visible
+  end
+
+  test "#visible_for? returns true by default" do
+    record = OpenStruct.new(id: 1)
+
+    assert @field.visible_for?(record)
+  end
+
+  test "#visible_for? returns true when visible proc returns true" do
+    @field.visible(->(record) { record.id.even? })
+
+    assert @field.visible_for?(OpenStruct.new(id: 2))
+  end
+
+  test "#visible_for? returns false when visible proc returns false" do
+    @field.visible(->(record) { record.id.even? })
+
+    assert_not @field.visible_for?(OpenStruct.new(id: 1))
+  end
 end

--- a/test/uchi/field_test.rb
+++ b/test/uchi/field_test.rb
@@ -75,8 +75,8 @@ class UchiFieldTest < ActiveSupport::TestCase
     assert_equal "Custom: Test", field.value(record)
   end
 
-  test "#visible returns nil by default" do
-    assert_nil @field.visible
+  test "#visible returns DEFAULT_VISIBLE by default" do
+    assert_equal Uchi::Field::Configuration::DEFAULT_VISIBLE, @field.visible
   end
 
   test "#visible sets a proc and returns self for chaining" do

--- a/test/uchi/field_test.rb
+++ b/test/uchi/field_test.rb
@@ -87,6 +87,12 @@ class UchiFieldTest < ActiveSupport::TestCase
     assert_equal proc, @field.visible
   end
 
+  test "#visible raises ArgumentError when passed a non-callable" do
+    assert_raises(ArgumentError) { @field.visible(nil) }
+    assert_raises(ArgumentError) { @field.visible(true) }
+    assert_raises(ArgumentError) { @field.visible("always") }
+  end
+
   test "#visible_for? returns true by default" do
     record = OpenStruct.new(id: 1)
 

--- a/test/uchi/repository_test.rb
+++ b/test/uchi/repository_test.rb
@@ -54,7 +54,7 @@ class UchiRepositoryTest < ActiveSupport::TestCase
   end
 
   test "#fields_for_show returns fields to include on the show page" do
-    fields = author_repository.fields_for_show
+    fields = author_repository.fields_for_show(record: Author.new)
 
     assert_equal [:id, :name, :born_on, :biography], fields.map(&:name)
   end

--- a/test/uchi/repository_test.rb
+++ b/test/uchi/repository_test.rb
@@ -42,7 +42,7 @@ class UchiRepositoryTest < ActiveSupport::TestCase
   end
 
   test "#fields_for_edit returns fields to include on the edit page" do
-    fields = author_repository.fields_for_edit
+    fields = author_repository.fields_for_edit(record: Author.new)
 
     assert_equal [:name, :born_on, :biography], fields.map(&:name)
   end

--- a/test/uchi/repository_test.rb
+++ b/test/uchi/repository_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "ostruct"
 
 require_relative "../dummy/app/uchi/repositories/author"
 
@@ -45,6 +46,36 @@ class UchiRepositoryTest < ActiveSupport::TestCase
     fields = author_repository.fields_for_edit(record: Author.new)
 
     assert_equal [:name, :born_on, :biography], fields.map(&:name)
+  end
+
+  test "#fields_for_edit excludes fields where visible returns false for the record" do
+    always_visible = Uchi::Field::String.new(:name)
+    conditionally_visible = Uchi::Field::String.new(:secret).visible(->(record) { record.admin })
+
+    repository = visibility_repository(always_visible, conditionally_visible)
+
+    assert_equal [:name], repository.fields_for_edit(record: OpenStruct.new(admin: false)).map(&:name)
+    assert_equal [:name, :secret], repository.fields_for_edit(record: OpenStruct.new(admin: true)).map(&:name)
+  end
+
+  test "#fields_for_new excludes fields where visible returns false for the record" do
+    always_visible = Uchi::Field::String.new(:name)
+    conditionally_visible = Uchi::Field::String.new(:secret).visible(->(record) { record.admin })
+
+    repository = visibility_repository(always_visible, conditionally_visible)
+
+    assert_equal [:name], repository.fields_for_new(record: OpenStruct.new(admin: false)).map(&:name)
+    assert_equal [:name, :secret], repository.fields_for_new(record: OpenStruct.new(admin: true)).map(&:name)
+  end
+
+  test "#fields_for_show excludes fields where visible returns false for the record" do
+    always_visible = Uchi::Field::String.new(:name)
+    conditionally_visible = Uchi::Field::String.new(:secret).visible(->(record) { record.admin })
+
+    repository = visibility_repository(always_visible, conditionally_visible)
+
+    assert_equal [:name], repository.fields_for_show(record: OpenStruct.new(admin: false)).map(&:name)
+    assert_equal [:name, :secret], repository.fields_for_show(record: OpenStruct.new(admin: true)).map(&:name)
   end
 
   test "#fields_for_index returns fields to include on the index page" do
@@ -153,5 +184,11 @@ class UchiRepositoryTest < ActiveSupport::TestCase
 
   def title_repository
     Uchi::Repositories::Title.new
+  end
+
+  def visibility_repository(*fields)
+    Class.new(Uchi::Repository) do
+      define_method(:fields) { fields }
+    end.new
   end
 end


### PR DESCRIPTION
Giving the field a `visible` lambda gives you more control over when to render a field:

```ruby
Field::Number.new(:discount).visible(->(record) { record.discountable? })
```

The lambda is passed the actual record and the field will be rendered if the lambda returns a truthy value.

Note that this is not usable for index pages. The index table header always shows all configured columns — since there's no single record to evaluate visibility against. To remove a column from the index page use `on([:edit, :new, :show])` instead.