### PR TITLE
Upgrade herb

### DIFF
--- a/.herb.yml
+++ b/.herb.yml
@@ -17,7 +17,6 @@ linter:
   enabled: true
   rules:
     {
-      html-require-script-nonce: { enabled: false },
       source-indentation: { enabled: false }
     }
 

--- a/.herb.yml
+++ b/.herb.yml
@@ -15,10 +15,6 @@ files:
 
 linter:
   enabled: true
-  rules:
-    {
-      source-indentation: { enabled: false }
-    }
 
 formatter:
   enabled: true

--- a/.herb.yml
+++ b/.herb.yml
@@ -1,4 +1,4 @@
-version: 0.8.7
+version: 0.10.1
 files:
   include:
     - "**/*.html"
@@ -13,7 +13,13 @@ files:
 
 linter:
   enabled: true
-  rules: {}
+  rules:
+    {
+      erb-no-output-in-attribute-position: { enabled: false },
+      erb-no-unsafe-raw: { enabled: false },
+      html-require-script-nonce: { enabled: false },
+      source-indentation: { enabled: false }
+    }
 
 formatter:
   enabled: true

--- a/.herb.yml
+++ b/.herb.yml
@@ -7,6 +7,7 @@ files:
     - "**/*.html+*.erb"
     - "**/*.turbo_stream.erb"
   exclude:
+    - app/components/uchi/flowbite/**/*
     - doc/**/*
     - node_modules/**/*
     - vendor/bundle/**/*

--- a/.herb.yml
+++ b/.herb.yml
@@ -17,7 +17,6 @@ linter:
   enabled: true
   rules:
     {
-      erb-no-unsafe-raw: { enabled: false },
       html-require-script-nonce: { enabled: false },
       source-indentation: { enabled: false }
     }

--- a/.herb.yml
+++ b/.herb.yml
@@ -17,7 +17,6 @@ linter:
   enabled: true
   rules:
     {
-      erb-no-output-in-attribute-position: { enabled: false },
       erb-no-unsafe-raw: { enabled: false },
       html-require-script-nonce: { enabled: false },
       source-indentation: { enabled: false }

--- a/.herb.yml
+++ b/.herb.yml
@@ -7,6 +7,7 @@ files:
     - "**/*.html+*.erb"
     - "**/*.turbo_stream.erb"
   exclude:
+    - doc/**/*
     - node_modules/**/*
     - vendor/bundle/**/*
     - coverage/**/*

--- a/Rakefile
+++ b/Rakefile
@@ -21,6 +21,12 @@ namespace :docs do
 end
 
 namespace :herb do
+  desc "Automatically fix Herb offenses in erb files"
+  task :fix do
+    sh "npm run herb:lint --fix"
+  end
+
+  desc "Lint erb files using Herb"
   task :lint do
     sh "npm run herb:lint"
   end

--- a/app/components/uchi/field/boolean/index.html.erb
+++ b/app/components/uchi/field/boolean/index.html.erb
@@ -1,9 +1,11 @@
-<% if field.value(record) %>
-  <svg class="w-5 h-5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+<svg class="w-5 h-5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+  <% if field.value(record) %>
+
     <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.5 11.5 11 14l4-4m6 2a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/>
-  </svg>
-<% else %>
-  <svg class="w-5 h-5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+
+  <% else %>
+
     <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7.757 12h8.486M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/>
-  </svg>
-<% end %>
+
+  <% end %>
+</svg>

--- a/app/components/uchi/field/boolean/show.html.erb
+++ b/app/components/uchi/field/boolean/show.html.erb
@@ -1,9 +1,11 @@
-<% if value %>
-  <svg class="w-5 h-5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+<svg class="w-5 h-5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+  <% if value %>
+
     <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.5 11.5 11 14l4-4m6 2a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/>
-  </svg>
-<% else %>
-  <svg class="w-5 h-5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+
+  <% else %>
+
     <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7.757 12h8.486M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/>
-  </svg>
-<% end %>
+
+  <% end %>
+</svg>

--- a/app/components/uchi/field/image/index.html.erb
+++ b/app/components/uchi/field/image/index.html.erb
@@ -1,7 +1,7 @@
 <% attachment = field.value(record) %>
 
 <% if attachment.attached? %>
-  <%= image_tag attachment.variant(resize_to_limit: [100, 100]), class: "h-12 w-12 object-cover rounded" %>
+  <%= image_tag attachment.variant(resize_to_limit: [100, 100]), alt: repository.translate.field_label(field), class: "h-12 w-12 object-cover rounded" %>
 <% else %>
   <%= render(Uchi::Ui::NoValue.new) %>
 <% end %>

--- a/app/components/uchi/field/image/show.html.erb
+++ b/app/components/uchi/field/image/show.html.erb
@@ -1,7 +1,7 @@
 <% attachment = value %>
 
 <% if attachment.attached? %>
-  <%= image_tag attachment, class: "max-w-full h-auto rounded-lg shadow-md" %>
+  <%= image_tag attachment, alt: repository.translate.field_label(field),class: "max-w-full h-auto rounded-lg shadow-md" %>
 <% else %>
   <%= render(Uchi::Ui::NoValue.new) %>
 <% end %>

--- a/app/views/layouts/uchi/_javascript.html.erb
+++ b/app/views/layouts/uchi/_javascript.html.erb
@@ -1,1 +1,1 @@
-<%= javascript_include_tag "uchi/application", "data-turbo-track": "reload" %>
+<%= javascript_include_tag "uchi/application", "data-turbo-track": "reload", nonce: true %>

--- a/app/views/uchi/has_many/associated_records/index.html.erb
+++ b/app/views/uchi/has_many/associated_records/index.html.erb
@@ -1,4 +1,4 @@
-<ul class="p-4 text-sm text-body font-medium space-y-4">
+<ul class="p-4 space-y-4 text-sm font-medium text-body">
   <% @records.each do |record| %>
     <%
       checkbox_id = dom_id(record, [source_repository.model, @field_name, 'checkbox'].join("-"))
@@ -12,14 +12,14 @@
         <input
           type="checkbox"
           id="<%= checkbox_id %>"
-          class="w-4 h-4 border border-default-strong rounded-xs bg-neutral-secondary-strong focus:ring-2 focus:ring-brand-soft cursor-pointer"
+          class="w-4 h-4 border cursor-pointer border-default-strong rounded-xs bg-neutral-secondary-strong focus:ring-2 focus:ring-brand-soft"
           data-action="change->has-many#handleCheckboxChange"
           data-has-many-target="checkbox"
           <% if @current_values.include?(record) %>
             checked
           <% end %>
         >
-        <label for="<%= checkbox_id %>" class="ms-2 text-sm font-medium text-heading cursor-pointer">
+        <label for="<%= checkbox_id %>" class="text-sm font-medium cursor-pointer ms-2 text-heading">
           <%= record_title(record) %>
         </label>
       </div>

--- a/app/views/uchi/has_many/associated_records/index.html.erb
+++ b/app/views/uchi/has_many/associated_records/index.html.erb
@@ -15,7 +15,9 @@
           class="w-4 h-4 border border-default-strong rounded-xs bg-neutral-secondary-strong focus:ring-2 focus:ring-brand-soft cursor-pointer"
           data-action="change->has-many#handleCheckboxChange"
           data-has-many-target="checkbox"
-          <%= 'checked' if @current_values.include?(record) %>
+          <% if @current_values.include?(record) %>
+            checked
+          <% end %>
         >
         <label for="<%= checkbox_id %>" class="ms-2 text-sm font-medium text-heading cursor-pointer">
           <%= record_title(record) %>


### PR DESCRIPTION
```
$ npx herb-lint --upgrade

↻ Checking 37 new rules against your codebase...

✓ Updated .herb.yml version from 0.8.7 to 0.10.1

✓ Enabled 33 new rules (no offenses found):

  ✓ actionview-no-silent-helper
  ✓ actionview-no-silent-render
  ✓ actionview-no-unnecessary-tag-attributes
  ✓ actionview-no-void-element-content
  ✓ actionview-strict-locals-partial-only
  ✓ erb-no-debug-output
  ✓ erb-no-empty-control-flow
  ✓ erb-no-conditional-html-element
  ✓ erb-no-conditional-open-tag
  ✓ erb-no-duplicate-branch-elements
  ✓ erb-no-inline-case-conditions
  ✓ erb-no-instance-variables-in-partials
  ✓ erb-no-interpolated-class-names
  ✓ erb-no-javascript-tag-helper
  ✓ erb-no-output-in-attribute-name
  ✓ erb-no-raw-output-in-attribute-value
  ✓ erb-no-unused-expressions
  ✓ erb-no-unused-literals
  ✓ erb-no-statement-in-script
  ✓ erb-no-then-in-control-flow
  ✓ erb-no-trailing-whitespace
  ✓ erb-no-unsafe-js-attribute
  ✓ erb-no-unsafe-script-interpolation
  ✓ erb-prefer-direct-output
  ✓ erb-strict-locals-comment-syntax
  ✓ html-allowed-script-type
  ✓ html-details-has-summary
  ✓ html-no-abstract-roles
  ✓ html-no-aria-hidden-on-body
  ✓ html-no-unescaped-entities
  ✓ html-no-unknown-tag
  ✓ html-require-closing-tags
  ✓ turbo-permanent-require-id

! Found 29048 offenses across 4 new rules. Disabled to ease the upgrade:

  ✗ erb-no-output-in-attribute-position (2 offenses)
  ✗ erb-no-unsafe-raw (1 offense)
  ✗ html-require-script-nonce (452 offenses)
  ✗ source-indentation (1 offense)

  When you're ready, review the disabled rules in your .herb.yml and re-enable them after fixing the offenses.
```