### PR TITLE
Call npm run properly

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,7 +23,7 @@ end
 namespace :herb do
   desc "Automatically fix Herb offenses in erb files"
   task :fix do
-    sh "npm run herb:lint --fix"
+    sh "npm run herb:lint -- --fix"
   end
 
   desc "Lint erb files using Herb"


### PR DESCRIPTION
Apparently npm run requires -- to forward flags to the underlying script; as written, --fix may be treated as an npm option/env var and not reach herb-lint, so the task may not actually fix offenses.