### PR TITLE
Attribute config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inklings of a plugin-system. For now, it's for internal use only.
 - A bunch of documentation with more to come.
 - Add `visible` configuration option to fields. This gives finer control over which fields are displayed for a given record, allowing for more dynamic and context-sensitive UIs.
+- Add `attribute` configuration option to fields. This allows you to have a field that is named one thing (for UI purposes, perhaps) while reading and writing a differently named attribute on the model.
 
 ### Fixed
 

--- a/app/components/uchi/field/belongs_to.rb
+++ b/app/components/uchi/field/belongs_to.rb
@@ -11,12 +11,12 @@ module Uchi
         end
 
         def associated_repository
-          reflection = record.class.reflect_on_association(field.name)
+          reflection = record.class.reflect_on_association(field.attribute)
 
           unless reflection
             raise \
               ArgumentError,
-              "No association named #{field.name.inspect} found on #{record.class}"
+              "No association named #{field.attribute.inspect} found on #{record.class}"
           end
 
           model = if reflection.polymorphic?
@@ -80,7 +80,7 @@ module Uchi
         end
 
         def reflection
-          @reflection ||= record.class.reflect_on_association(field.name)
+          @reflection ||= record.class.reflect_on_association(field.attribute)
         end
       end
 
@@ -153,7 +153,7 @@ module Uchi
       def param_key
         # TODO: This is too naive. We need to match this to the actual foreign
         # key of the model.
-        :"#{name}_id"
+        :"#{attribute}_id"
       end
 
       private
@@ -161,7 +161,7 @@ module Uchi
       def polymorphic?
         return false unless repository
 
-        reflection = repository.model.reflect_on_association(name)
+        reflection = repository.model.reflect_on_association(attribute)
         reflection&.polymorphic? || false
       end
     end

--- a/app/components/uchi/field/boolean.rb
+++ b/app/components/uchi/field/boolean.rb
@@ -8,7 +8,7 @@ module Uchi
 
         def options
           options = {
-            attribute: field.name,
+            attribute: field.attribute,
             form: form,
             label: {content: label}
           }

--- a/app/components/uchi/field/date.rb
+++ b/app/components/uchi/field/date.rb
@@ -8,7 +8,7 @@ module Uchi
 
         def options
           options = {
-            attribute: field.name,
+            attribute: field.attribute,
             form: form,
             label: {content: label}
           }

--- a/app/components/uchi/field/date_time.rb
+++ b/app/components/uchi/field/date_time.rb
@@ -8,7 +8,7 @@ module Uchi
 
         def options
           options = {
-            attribute: field.name,
+            attribute: field.attribute,
             form: form,
             label: {content: label}
           }

--- a/app/components/uchi/field/file.rb
+++ b/app/components/uchi/field/file.rb
@@ -8,7 +8,7 @@ module Uchi
 
         def options
           options = {
-            attribute: field.name,
+            attribute: field.attribute,
             form: form,
             label: {content: label}
           }

--- a/app/components/uchi/field/image.rb
+++ b/app/components/uchi/field/image.rb
@@ -8,7 +8,7 @@ module Uchi
 
         def options
           options = {
-            attribute: field.name,
+            attribute: field.attribute,
             form: form,
             label: {content: label},
             input: {options: {accept: "image/*"}}

--- a/app/components/uchi/field/number.rb
+++ b/app/components/uchi/field/number.rb
@@ -8,7 +8,7 @@ module Uchi
 
         def options
           options = {
-            attribute: field.name,
+            attribute: field.attribute,
             form: form,
             label: {content: label}
           }

--- a/app/components/uchi/field/string.rb
+++ b/app/components/uchi/field/string.rb
@@ -8,7 +8,7 @@ module Uchi
 
         def options
           options = {
-            attribute: field.name,
+            attribute: field.attribute,
             form: form,
             label: {content: label}
           }

--- a/app/components/uchi/field/text.rb
+++ b/app/components/uchi/field/text.rb
@@ -8,7 +8,7 @@ module Uchi
 
         def options
           options = {
-            attribute: field.name,
+            attribute: field.attribute,
             form: form,
             label: {content: label},
             input: {options: {rows: 8}}

--- a/app/components/uchi/ui/index/records_table/records_table.html.erb
+++ b/app/components/uchi/ui/index/records_table/records_table.html.erb
@@ -15,9 +15,9 @@
           class="px-6 py-3 font-medium whitespace-nowrap <%= component_class.classes_for_table_cell.join(" ") %>"
         >
           <% if field.sortable? %>
-            <% if field.name == sort_order&.name %>
+            <% if field.attribute == sort_order&.attribute %>
               <% if sort_order&.ascending? %>
-                <%= link_to(repository.routes.path_for(:index, query: query, scope: scope, sort: {:by => field.name, :direction => :desc})) do %>
+                <%= link_to(repository.routes.path_for(:index, query: query, scope: scope, sort: {:by => field.attribute, :direction => :desc})) do %>
                   <%= repository.translate.field_label(field) %>
 
                   <svg
@@ -39,7 +39,7 @@
                   </svg>
                 <% end %>
               <% else %>
-                <%= link_to(repository.routes.path_for(:index, query: query, scope: scope, sort: {:by => field.name, :direction => :asc})) do %>
+                <%= link_to(repository.routes.path_for(:index, query: query, scope: scope, sort: {:by => field.attribute, :direction => :asc})) do %>
                   <%= repository.translate.field_label(field) %>
 
                   <svg
@@ -62,7 +62,7 @@
                 <% end %>
               <% end %>
             <% else %>
-              <%= link_to(repository.routes.path_for(:index, query: query, scope: scope, sort: {:by => field.name, :direction => :asc})) do %>
+              <%= link_to(repository.routes.path_for(:index, query: query, scope: scope, sort: {:by => field.attribute, :direction => :asc})) do %>
                 <%= repository.translate.field_label(field) %>
 
                 <svg

--- a/lib/uchi/field.rb
+++ b/lib/uchi/field.rb
@@ -64,7 +64,7 @@ module Uchi
 
     # Returns the key that this field is expected to use in params
     def param_key
-      name.to_sym
+      attribute
     end
 
     # Returns the values to use for permitting this field in strong parameters
@@ -85,7 +85,7 @@ module Uchi
     end
 
     def value(record)
-      reader.call(record, name)
+      reader.call(record, attribute)
     end
   end
 end

--- a/lib/uchi/field/configuration.rb
+++ b/lib/uchi/field/configuration.rb
@@ -17,6 +17,28 @@ module Uchi
         @sortable = default_sortable?
       end
 
+      # Sets or gets the model attribute name this field reads from.
+      #
+      # When called with an argument, sets the attribute and returns self for chaining.
+      # When called without arguments, returns the configured attribute name, or falls
+      # back to the field's name if no attribute has been configured.
+      #
+      # @param attribute_name [Symbol, String] The name of the model attribute
+      # @return [self, Symbol] Returns self for method chaining when setting,
+      #   or the attribute name when getting
+      #
+      # @example Setting
+      #   Field::BelongsTo.new(:company).attribute(:owner)
+      #
+      # @example Getting
+      #   field.attribute # => :company (default) or :owner (if explicitly set)
+      def attribute(attribute_name = Configuration::Unset)
+        return @attribute || name if attribute_name == Configuration::Unset
+
+        @attribute = attribute_name.to_sym
+        self
+      end
+
       # Sets or gets which actions this field should appear on.
       #
       # When called with arguments, sets the actions and returns self for chaining.

--- a/lib/uchi/repository.rb
+++ b/lib/uchi/repository.rb
@@ -200,7 +200,7 @@ module Uchi
     end
 
     def apply_sort_order(query, sort_order)
-      field_to_sort_by = fields.find { |field| field.name == sort_order.name }
+      field_to_sort_by = fields.find { |field| field.attribute == sort_order.attribute }
       return query unless field_to_sort_by
 
       if field_to_sort_by.sortable.respond_to?(:call)

--- a/lib/uchi/repository.rb
+++ b/lib/uchi/repository.rb
@@ -190,7 +190,7 @@ module Uchi
 
       search = search.strip
       conditions = searchable_fields.map { |field|
-        arel_field = model.arel_table[field.name]
+        arel_field = model.arel_table[field.attribute]
         Arel::Nodes::NamedFunction.new(
           "CAST",
           [arel_field.as(Arel::Nodes::SqlLiteral.new("VARCHAR"))]

--- a/lib/uchi/sort_order.rb
+++ b/lib/uchi/sort_order.rb
@@ -1,6 +1,6 @@
 module Uchi
   class SortOrder
-    attr_reader :name, :direction
+    attr_reader :attribute, :direction
 
     class << self
       def from_params(params)
@@ -20,15 +20,15 @@ module Uchi
     end
 
     def apply(query)
-      query.order(name => direction)
+      query.order(attribute => direction)
     end
 
     def descending?
       direction == :desc
     end
 
-    def initialize(name, direction)
-      @name = name.to_sym
+    def initialize(attribute, direction)
+      @attribute = attribute.to_sym
       @direction = direction.to_sym
     end
   end

--- a/test/components/uchi/field/belongs_to_test.rb
+++ b/test/components/uchi/field/belongs_to_test.rb
@@ -36,6 +36,11 @@ module Uchi
         assert_equal :book_id, @field.param_key
       end
 
+      test "#param_key uses configured attribute when set" do
+        field = Uchi::Field::BelongsTo.new(:publication).attribute(:book)
+        assert_equal :book_id, field.param_key
+      end
+
       test "#edit_component returns an instance of Edit component" do
         component = @field.edit_component(form: @form, hint: "Custom hint", label: "Custom label", repository: @repository)
         assert_equal "Custom hint", component.hint

--- a/test/uchi/field_test.rb
+++ b/test/uchi/field_test.rb
@@ -6,6 +6,26 @@ class UchiFieldTest < ActiveSupport::TestCase
     @field = Uchi::Field.new(:name)
   end
 
+  test "#attribute defaults to name" do
+    field = Uchi::Field.new(:title)
+    assert_equal :title, field.attribute
+  end
+
+  test "#attribute returns configured attribute when set" do
+    field = Uchi::Field.new(:company).attribute(:owner)
+    assert_equal :owner, field.attribute
+  end
+
+  test "#attribute name is still accessible after setting attribute" do
+    field = Uchi::Field.new(:company).attribute(:owner)
+    assert_equal :company, field.name
+  end
+
+  test "#attribute returns self for method chaining" do
+    field = Uchi::Field.new(:company)
+    assert_equal field, field.attribute(:owner)
+  end
+
   test "initializes with name" do
     field = Uchi::Field.new(:title)
     assert_equal :title, field.name
@@ -28,6 +48,11 @@ class UchiFieldTest < ActiveSupport::TestCase
 
   test "#param_key returns name as symbol" do
     assert_equal :name, @field.param_key
+  end
+
+  test "#param_key returns configured attribute when set" do
+    field = Uchi::Field.new(:company).attribute(:owner)
+    assert_equal :owner, field.param_key
   end
 
   test "#permitted_param returns name as symbol" do
@@ -65,6 +90,12 @@ class UchiFieldTest < ActiveSupport::TestCase
   test "#value uses reader to get value from record" do
     record = OpenStruct.new(name: "Test Name")
     assert_equal "Test Name", @field.value(record)
+  end
+
+  test "#value uses configured attribute when set" do
+    field = Uchi::Field.new(:company).attribute(:owner)
+    record = OpenStruct.new(owner: "Acme Corp")
+    assert_equal "Acme Corp", field.value(record)
   end
 
   test "#value uses custom reader when provided" do

--- a/test/uchi/repository_test.rb
+++ b/test/uchi/repository_test.rb
@@ -38,7 +38,7 @@ class UchiRepositoryTest < ActiveSupport::TestCase
     sort_order = author_repository.default_sort_order
 
     assert sort_order.is_a?(Uchi::SortOrder)
-    assert_equal :id, sort_order.name
+    assert_equal :id, sort_order.attribute
     assert_equal :asc, sort_order.direction
   end
 

--- a/test/uchi/sort_order_test.rb
+++ b/test/uchi/sort_order_test.rb
@@ -8,14 +8,14 @@ class UchiSortOrderTest < ActiveSupport::TestCase
   test ".from_params defaults to ascending when direction isn't given" do
     sort_order = Uchi::SortOrder.from_params(sort: {by: :name})
     assert_instance_of Uchi::SortOrder, sort_order
-    assert_equal :name, sort_order.name
+    assert_equal :name, sort_order.attribute
     assert_equal :asc, sort_order.direction
   end
 
   test ".from_params returns a new SortOrder when both 'by' and 'direction' are given" do
     sort_order = Uchi::SortOrder.from_params(sort: {by: :born_on, direction: :desc})
     assert_instance_of Uchi::SortOrder, sort_order
-    assert_equal :born_on, sort_order.name
+    assert_equal :born_on, sort_order.attribute
     assert_equal :desc, sort_order.direction
   end
 


### PR DESCRIPTION
In some cases it might be beneficial to have a field that is named differently than the attribute it reads from on the model. This commit adds a new configuration option for fields called `attribute` that allows you to specify the model attribute name that the field should read from:

    Field::BelongsTo.new(:company).attribute(:owner)

would case the field to read from the `owner` attribute on the model instead of the default `company` attribute.