### PR TITLE
Make HasMany and HasAndBelongsToMany sortable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow UI to use the full height of the viewport to prevent clipping popovers and dialogs.
 - BelongsTo fields for polymorphic associations no longer cause an error on edit and new pages. Instead, they just don't show up. This isn't exactly optimal, but for now we don't have an automated way of actually figuring out what ActiveRecord class they are associated with.
 - Scrolling could result in scrolling entirely past all the content. The inline scrolling of each individidual pane should now be much more robust.
+- Columns with HasMany and HasAndBelongsToMany fields can now be succesfully sorted on index pages instead of giving an error.
 
 ### Removed
 

--- a/app/components/uchi/field/file.rb
+++ b/app/components/uchi/field/file.rb
@@ -29,7 +29,7 @@ module Uchi
         false
       end
 
-      def default_sortable?
+      def default_sortable
         false
       end
     end

--- a/app/components/uchi/field/has_and_belongs_to_many.rb
+++ b/app/components/uchi/field/has_and_belongs_to_many.rb
@@ -127,11 +127,15 @@ module Uchi
         @association ||= repository.model.reflect_on_association(name)
       end
 
-
       protected
 
       def default_sortable?
-        false
+        lambda { |query, direction|
+          query
+            .left_outer_joins(name)
+            .group("#{query.klass.table_name}.#{query.klass.primary_key}")
+            .order(Arel.sql("COUNT(*) #{direction}"))
+        }
       end
     end
   end

--- a/app/components/uchi/field/has_and_belongs_to_many.rb
+++ b/app/components/uchi/field/has_and_belongs_to_many.rb
@@ -129,7 +129,7 @@ module Uchi
 
       protected
 
-      def default_sortable?
+      def default_sortable
         lambda { |query, direction|
           query
             .left_outer_joins(name)

--- a/app/components/uchi/field/has_and_belongs_to_many.rb
+++ b/app/components/uchi/field/has_and_belongs_to_many.rb
@@ -126,6 +126,13 @@ module Uchi
       def association
         @association ||= repository.model.reflect_on_association(name)
       end
+
+
+      protected
+
+      def default_sortable?
+        false
+      end
     end
   end
 end

--- a/app/components/uchi/field/has_and_belongs_to_many.rb
+++ b/app/components/uchi/field/has_and_belongs_to_many.rb
@@ -131,10 +131,17 @@ module Uchi
 
       def default_sortable
         lambda { |query, direction|
+          safe_direction = (direction.to_s.upcase == "DESC") ? "DESC" : "ASC"
+          reflection = query.klass.reflect_on_association(name)
+          return query unless reflection
+
+          associated_table = reflection.klass.table_name
+          associated_pk = reflection.klass.primary_key
+
           query
             .left_outer_joins(name)
             .group("#{query.klass.table_name}.#{query.klass.primary_key}")
-            .order(Arel.sql("COUNT(*) #{direction}"))
+            .order(Arel.sql("COUNT(#{associated_table}.#{associated_pk}) #{safe_direction}"))
         }
       end
     end

--- a/app/components/uchi/field/has_many.rb
+++ b/app/components/uchi/field/has_many.rb
@@ -155,10 +155,17 @@ module Uchi
 
       def default_sortable
         lambda { |query, direction|
+          safe_direction = (direction.to_s.upcase == "DESC") ? "DESC" : "ASC"
+          reflection = query.klass.reflect_on_association(name)
+          return query unless reflection
+
+          associated_table = reflection.klass.table_name
+          associated_pk = reflection.klass.primary_key
+
           query
             .left_outer_joins(name)
             .group("#{query.klass.table_name}.#{query.klass.primary_key}")
-            .order(Arel.sql("COUNT(*) #{direction}"))
+            .order(Arel.sql("COUNT(#{associated_table}.#{associated_pk}) #{safe_direction}"))
         }
       end
     end

--- a/app/components/uchi/field/has_many.rb
+++ b/app/components/uchi/field/has_many.rb
@@ -153,7 +153,7 @@ module Uchi
 
       protected
 
-      def default_sortable?
+      def default_sortable
         lambda { |query, direction|
           query
             .left_outer_joins(name)

--- a/app/components/uchi/field/has_many.rb
+++ b/app/components/uchi/field/has_many.rb
@@ -150,6 +150,12 @@ module Uchi
       def permitted_param
         {param_key => []}
       end
+
+      protected
+
+      def default_sortable?
+        false
+      end
     end
   end
 end

--- a/app/components/uchi/field/has_many.rb
+++ b/app/components/uchi/field/has_many.rb
@@ -154,7 +154,12 @@ module Uchi
       protected
 
       def default_sortable?
-        false
+        lambda { |query, direction|
+          query
+            .left_outer_joins(name)
+            .group("#{query.klass.table_name}.#{query.klass.primary_key}")
+            .order(Arel.sql("COUNT(*) #{direction}"))
+        }
       end
     end
   end

--- a/app/components/uchi/field/image.rb
+++ b/app/components/uchi/field/image.rb
@@ -30,7 +30,7 @@ module Uchi
         false
       end
 
-      def default_sortable?
+      def default_sortable
         false
       end
     end

--- a/lib/uchi/field/configuration.rb
+++ b/lib/uchi/field/configuration.rb
@@ -14,7 +14,7 @@ module Uchi
         @reader = DEFAULT_READER
         @searchable = default_searchable?
         @visible = DEFAULT_VISIBLE
-        @sortable = default_sortable?
+        @sortable = default_sortable
       end
 
       # Sets or gets which actions this field should appear on.
@@ -147,7 +147,7 @@ module Uchi
 
       # Returns true if the field is sortable
       def sortable?
-        return default_sortable? if @sortable.nil?
+        return default_sortable if @sortable.nil?
 
         !!@sortable
       end
@@ -173,7 +173,7 @@ module Uchi
         false
       end
 
-      def default_sortable?
+      def default_sortable
         true
       end
     end

--- a/test/uchi/repository_test.rb
+++ b/test/uchi/repository_test.rb
@@ -120,6 +120,60 @@ class UchiRepositoryTest < ActiveSupport::TestCase
     assert_equal [bob, alice], authors
   end
 
+  test "#find_all sorts by has_many association count ascending" do
+    book_two = Book.create!(original_title: "Two Titles")
+    book_zero = Book.create!(original_title: "Zero Titles")
+    book_one = Book.create!(original_title: "One Title")
+    Title.create!(book: book_two, title: "A")
+    Title.create!(book: book_two, title: "B")
+    Title.create!(book: book_one, title: "C")
+
+    books = book_repository.find_all(sort_order: Uchi::SortOrder.new(:titles, :asc))
+
+    assert_equal [book_zero, book_one, book_two], books
+  end
+
+  test "#find_all sorts by has_many association count descending" do
+    book_two = Book.create!(original_title: "Two Titles")
+    book_zero = Book.create!(original_title: "Zero Titles")
+    book_one = Book.create!(original_title: "One Title")
+    Title.create!(book: book_two, title: "A")
+    Title.create!(book: book_two, title: "B")
+    Title.create!(book: book_one, title: "C")
+
+    books = book_repository.find_all(sort_order: Uchi::SortOrder.new(:titles, :desc))
+
+    assert_equal [book_two, book_one, book_zero], books
+  end
+
+  test "#find_all sorts by has_and_belongs_to_many association count ascending" do
+    author_two = Author.create!(name: "Two Books")
+    author_zero = Author.create!(name: "Zero Books")
+    author_one = Author.create!(name: "One Book")
+    book_a = Book.create!(original_title: "Book A")
+    book_b = Book.create!(original_title: "Book B")
+    author_two.books = [book_a, book_b]
+    author_one.books = [book_a]
+
+    authors = habtm_author_repository.find_all(sort_order: Uchi::SortOrder.new(:books, :asc))
+
+    assert_equal [author_zero, author_one, author_two], authors
+  end
+
+  test "#find_all sorts by has_and_belongs_to_many association count descending" do
+    author_two = Author.create!(name: "Two Books")
+    author_zero = Author.create!(name: "Zero Books")
+    author_one = Author.create!(name: "One Book")
+    book_a = Book.create!(original_title: "Book A")
+    book_b = Book.create!(original_title: "Book B")
+    author_two.books = [book_a, book_b]
+    author_one.books = [book_a]
+
+    authors = habtm_author_repository.find_all(sort_order: Uchi::SortOrder.new(:books, :desc))
+
+    assert_equal [author_two, author_one, author_zero], authors
+  end
+
   test "#find returns a single record by its ID" do
     alice = Author.create!(name: "Alice")
 
@@ -184,6 +238,13 @@ class UchiRepositoryTest < ActiveSupport::TestCase
 
   def title_repository
     Uchi::Repositories::Title.new
+  end
+
+  def habtm_author_repository
+    Class.new(Uchi::Repository) do
+      define_singleton_method(:model) { Author }
+      define_method(:fields) { [Uchi::Field::HasAndBelongsToMany.new(:books)] }
+    end.new
   end
 
   def visibility_repository(*fields)


### PR DESCRIPTION
Columns with HasMany and HasManyAndBelongsTo fields can now be succesfully sorted on index pages instead of giving an error.