### PR TITLE
Don't load statistics tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,6 @@ require "standard/rake"
 
 APP_RAKEFILE = File.expand_path("test/dummy/Rakefile", __dir__)
 load "rails/tasks/engine.rake"
-load "rails/tasks/statistics.rake"
 
 namespace :docs do
   desc "Build documentation using Docyard"


### PR DESCRIPTION
It's being deprecated:

> DEPRECATION WARNING: rails/tasks/statistics.rake is deprecated and
> will be removed in Rails 8.2 without replacement.