### PR TITLE
Sort has many associations by count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking
+
+- `Uchi::SortOrder#name` has been renamed to `Uchi::SortOrder#column`.
+
 ### Added
 
 - Fields can now be configured to appear on :new pages, but not on :edit, and vice versa. Either add or remove `:new` from the fields `on()` configuration as needed.

--- a/app/components/uchi/field/file.rb
+++ b/app/components/uchi/field/file.rb
@@ -29,7 +29,7 @@ module Uchi
         false
       end
 
-      def default_sortable?
+      def default_sortable
         false
       end
     end

--- a/app/components/uchi/field/has_and_belongs_to_many.rb
+++ b/app/components/uchi/field/has_and_belongs_to_many.rb
@@ -126,6 +126,22 @@ module Uchi
       def association
         @association ||= repository.model.reflect_on_association(name)
       end
+
+      def default_sortable?
+        lambda { |query, direction|
+          safe_direction = (direction.to_s.upcase == "DESC") ? "DESC" : "ASC"
+          reflection = query.klass.reflect_on_association(name)
+          return query unless reflection
+
+          associated_table = reflection.klass.table_name
+          associated_pk = reflection.klass.primary_key
+
+          query
+            .left_outer_joins(name)
+            .group("#{query.klass.table_name}.#{query.klass.primary_key}")
+            .order(Arel.sql("COUNT(#{associated_table}.#{associated_pk}) #{safe_direction}"))
+        }
+      end
     end
   end
 end

--- a/app/components/uchi/field/has_and_belongs_to_many.rb
+++ b/app/components/uchi/field/has_and_belongs_to_many.rb
@@ -129,17 +129,18 @@ module Uchi
 
       def default_sortable?
         lambda { |query, direction|
-          safe_direction = (direction.to_s.upcase == "DESC") ? "DESC" : "ASC"
           reflection = query.klass.reflect_on_association(name)
           return query unless reflection
 
           associated_table = reflection.klass.table_name
           associated_pk = reflection.klass.primary_key
+          count = Arel.sql("COUNT(#{associated_table}.#{associated_pk})")
 
-          query
-            .left_outer_joins(name)
-            .group("#{query.klass.table_name}.#{query.klass.primary_key}")
-            .order(Arel.sql("COUNT(#{associated_table}.#{associated_pk}) #{safe_direction}"))
+          SortOrder.new(count, direction).apply(
+            query
+              .left_outer_joins(name)
+              .group("#{query.klass.table_name}.#{query.klass.primary_key}")
+          )
         }
       end
     end

--- a/app/components/uchi/field/has_and_belongs_to_many.rb
+++ b/app/components/uchi/field/has_and_belongs_to_many.rb
@@ -127,7 +127,7 @@ module Uchi
         @association ||= repository.model.reflect_on_association(name)
       end
 
-      def default_sortable?
+      def default_sortable
         lambda { |query, direction|
           reflection = query.klass.reflect_on_association(name)
           return query unless reflection

--- a/app/components/uchi/field/has_and_belongs_to_many.rb
+++ b/app/components/uchi/field/has_and_belongs_to_many.rb
@@ -133,14 +133,15 @@ module Uchi
           return query unless reflection
 
           associated_table = reflection.klass.table_name
-          associated_pk = reflection.klass.primary_key
-          count = Arel.sql("COUNT(#{associated_table}.#{associated_pk})")
+          associated_primary_key = reflection.klass.primary_key
+          count = Arel.sql("COUNT(#{associated_table}.#{associated_primary_key})")
+          primary_key = query.klass.arel_table[query.klass.primary_key]
 
           SortOrder.new(count, direction).apply(
             query
               .left_outer_joins(name)
-              .group("#{query.klass.table_name}.#{query.klass.primary_key}")
-          )
+              .group(primary_key)
+          ).order(primary_key.asc)
         }
       end
     end

--- a/app/components/uchi/field/has_many.rb
+++ b/app/components/uchi/field/has_many.rb
@@ -155,17 +155,18 @@ module Uchi
 
       def default_sortable?
         lambda { |query, direction|
-          safe_direction = (direction.to_s.upcase == "DESC") ? "DESC" : "ASC"
           reflection = query.klass.reflect_on_association(name)
           return query unless reflection
 
           associated_table = reflection.klass.table_name
           associated_pk = reflection.klass.primary_key
+          count = Arel.sql("COUNT(#{associated_table}.#{associated_pk})")
 
-          query
-            .left_outer_joins(name)
-            .group("#{query.klass.table_name}.#{query.klass.primary_key}")
-            .order(Arel.sql("COUNT(#{associated_table}.#{associated_pk}) #{safe_direction}"))
+          SortOrder.new(count, direction).apply(
+            query
+              .left_outer_joins(name)
+              .group("#{query.klass.table_name}.#{query.klass.primary_key}")
+          )
         }
       end
     end

--- a/app/components/uchi/field/has_many.rb
+++ b/app/components/uchi/field/has_many.rb
@@ -150,6 +150,24 @@ module Uchi
       def permitted_param
         {param_key => []}
       end
+
+      protected
+
+      def default_sortable?
+        lambda { |query, direction|
+          safe_direction = (direction.to_s.upcase == "DESC") ? "DESC" : "ASC"
+          reflection = query.klass.reflect_on_association(name)
+          return query unless reflection
+
+          associated_table = reflection.klass.table_name
+          associated_pk = reflection.klass.primary_key
+
+          query
+            .left_outer_joins(name)
+            .group("#{query.klass.table_name}.#{query.klass.primary_key}")
+            .order(Arel.sql("COUNT(#{associated_table}.#{associated_pk}) #{safe_direction}"))
+        }
+      end
     end
   end
 end

--- a/app/components/uchi/field/has_many.rb
+++ b/app/components/uchi/field/has_many.rb
@@ -159,14 +159,15 @@ module Uchi
           return query unless reflection
 
           associated_table = reflection.klass.table_name
-          associated_pk = reflection.klass.primary_key
-          count = Arel.sql("COUNT(#{associated_table}.#{associated_pk})")
+          associated_primary_key = reflection.klass.primary_key
+          count = Arel.sql("COUNT(#{associated_table}.#{associated_primary_key})")
+          primary_key = query.klass.arel_table[query.klass.primary_key]
 
           SortOrder.new(count, direction).apply(
             query
               .left_outer_joins(name)
-              .group("#{query.klass.table_name}.#{query.klass.primary_key}")
-          )
+              .group(primary_key)
+          ).order(primary_key.asc)
         }
       end
     end

--- a/app/components/uchi/field/has_many.rb
+++ b/app/components/uchi/field/has_many.rb
@@ -153,7 +153,7 @@ module Uchi
 
       protected
 
-      def default_sortable?
+      def default_sortable
         lambda { |query, direction|
           reflection = query.klass.reflect_on_association(name)
           return query unless reflection

--- a/app/components/uchi/field/image.rb
+++ b/app/components/uchi/field/image.rb
@@ -30,7 +30,7 @@ module Uchi
         false
       end
 
-      def default_sortable?
+      def default_sortable
         false
       end
     end

--- a/app/components/uchi/ui/index/records_table/records_table.html.erb
+++ b/app/components/uchi/ui/index/records_table/records_table.html.erb
@@ -15,7 +15,7 @@
           class="px-6 py-3 font-medium whitespace-nowrap <%= component_class.classes_for_table_cell.join(" ") %>"
         >
           <% if field.sortable? %>
-            <% if field.name == sort_order&.name %>
+            <% if field.name == sort_order&.column %>
               <% if sort_order&.ascending? %>
                 <%= link_to(repository.routes.path_for(:index, query: query, scope: scope, sort: {:by => field.name, :direction => :desc})) do %>
                   <%= repository.translate.field_label(field) %>

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -58,14 +58,14 @@ Uchi casts whatever datatype the field uses into a string when searching and per
 
 ## Sorting
 
-All fields are considered sortable by default. This means that a link to toggle the order of a column appears for all columns on index pages. How to sort a specific field - or to disable it entirely - is configured using the `:sortable` option.
+When a `sortable` field appears on the index page, it gets a link to toggle the order of the records based on the field. How to sort a specific field - or to disable it entirely - is configured using the `sortable` method.
 
-### Disable sorting
+### Enable sorting
 
-To disable sorting a specific field:
+Most fields are sortable by default, but if you need to enable sortable for a given field you can set it to `true`:
 
 ```ruby
-Field::Number.new(:calculated_sum).sortable(false)
+Field::String.new(:name).sortable(true)
 ```
 
 ### Customize sorting
@@ -73,8 +73,8 @@ Field::Number.new(:calculated_sum).sortable(false)
 To customize the query used to sort by a given field, pass a lambda to the `sortable` method:
 
 ```ruby
-Field::Number.new(:users_count).sortable(lambda { |query, direction|
-  query.joins(:users).group(:id).order("COUNT(users.id) #{direction}")
+Field::String.new(:name).sortable(lambda { |query, direction|
+  query.order(first_name: direction, last_names: direction)
 })
 ```
 
@@ -85,6 +85,14 @@ The lambda receives 2 arguments:
 
 The lambda should return an `ActiveRecord::Relation` with the desired sort order added.
 
+You can even use this to sort by computed columns via SQL:
+
+```ruby
+Field::Number.new(:users_count).sortable(lambda { |query, direction|
+  query.joins(:users).group(:id).order("COUNT(users.id) #{direction}")
+})
+```
+
 ### Sorting by columns in another table
 
 Thanks to ActiveRecord we can even sort by columns in other tables/models. If you have an `Employee` model that belongs to a `Company` and you want to allow your users to sort the employee list by company name, you can configure the field like this:
@@ -93,6 +101,14 @@ Thanks to ActiveRecord we can even sort by columns in other tables/models. If yo
 Field::BelongsTo.new(:company).sortable(lambda { |query, direction|
   query.joins(:office).order(:offices => {:name => direction})
 })
+```
+
+### Disable sorting
+
+To disable sorting a specific field:
+
+```ruby
+Field::Number.new(:calculated_sum).sortable(false)
 ```
 
 ## Field::BelongsTo

--- a/lib/uchi/field/configuration.rb
+++ b/lib/uchi/field/configuration.rb
@@ -139,7 +139,7 @@ module Uchi
       # @example Getting
       #   field.sortable # => true
       def sortable(value = Configuration::Unset)
-        return @sortable if value == Configuration::Unset
+        return @sortable.nil? ? default_sortable? : @sortable if value == Configuration::Unset
 
         @sortable = value
         self
@@ -147,9 +147,7 @@ module Uchi
 
       # Returns true if the field is sortable
       def sortable?
-        return default_sortable? if @sortable.nil?
-
-        !!@sortable
+        !!sortable
       end
 
       # Returns whether this field should be visible for the given record.

--- a/lib/uchi/field/configuration.rb
+++ b/lib/uchi/field/configuration.rb
@@ -14,7 +14,7 @@ module Uchi
         @reader = DEFAULT_READER
         @searchable = default_searchable?
         @visible = DEFAULT_VISIBLE
-        @sortable = default_sortable?
+        @sortable = default_sortable
       end
 
       # Sets or gets which actions this field should appear on.
@@ -139,7 +139,7 @@ module Uchi
       # @example Getting
       #   field.sortable # => true
       def sortable(value = Configuration::Unset)
-        return @sortable.nil? ? default_sortable? : @sortable if value == Configuration::Unset
+        return @sortable.nil? ? default_sortable : @sortable if value == Configuration::Unset
 
         @sortable = value
         self
@@ -171,7 +171,7 @@ module Uchi
         false
       end
 
-      def default_sortable?
+      def default_sortable
         true
       end
     end

--- a/lib/uchi/repository.rb
+++ b/lib/uchi/repository.rb
@@ -200,7 +200,7 @@ module Uchi
     end
 
     def apply_sort_order(query, sort_order)
-      field_to_sort_by = fields.find { |field| field.name == sort_order.name }
+      field_to_sort_by = fields.find { |field| field.name == sort_order.column }
       return query unless field_to_sort_by
 
       if field_to_sort_by.sortable.respond_to?(:call)

--- a/lib/uchi/sort_order.rb
+++ b/lib/uchi/sort_order.rb
@@ -1,4 +1,5 @@
 module Uchi
+  # Encapsulates the sort order selected by a user.
   class SortOrder
     attr_reader :column, :direction
 

--- a/lib/uchi/sort_order.rb
+++ b/lib/uchi/sort_order.rb
@@ -1,6 +1,6 @@
 module Uchi
   class SortOrder
-    attr_reader :name, :direction
+    attr_reader :column, :direction
 
     class << self
       def from_params(params)
@@ -20,15 +20,15 @@ module Uchi
     end
 
     def apply(query)
-      query.order(name => direction)
+      query.order(column => direction)
     end
 
     def descending?
       direction == :desc
     end
 
-    def initialize(name, direction)
-      @name = name.to_sym
+    def initialize(column, direction)
+      @column = column.to_sym
       @direction = direction.to_sym
     end
   end

--- a/lib/uchi/sort_order.rb
+++ b/lib/uchi/sort_order.rb
@@ -21,7 +21,11 @@ module Uchi
     end
 
     def apply(query)
-      query.order(column => direction)
+      if column.respond_to?(:asc)
+        query.order(ascending? ? column.asc : column.desc)
+      else
+        query.order(column => direction)
+      end
     end
 
     def descending?
@@ -29,7 +33,7 @@ module Uchi
     end
 
     def initialize(column, direction)
-      @column = column.to_sym
+      @column = column.respond_to?(:asc) ? column : column.to_sym
       @direction = direction.to_sym
     end
   end

--- a/test/uchi/repository_test.rb
+++ b/test/uchi/repository_test.rb
@@ -120,6 +120,60 @@ class UchiRepositoryTest < ActiveSupport::TestCase
     assert_equal [bob, alice], authors
   end
 
+  test "#find_all sorts by has_many association count ascending" do
+    book_two = Book.create!(original_title: "Two Titles")
+    book_zero = Book.create!(original_title: "Zero Titles")
+    book_one = Book.create!(original_title: "One Title")
+    Title.create!(book: book_two, title: "A")
+    Title.create!(book: book_two, title: "B")
+    Title.create!(book: book_one, title: "C")
+
+    books = book_repository.find_all(sort_order: Uchi::SortOrder.new(:titles, :asc))
+
+    assert_equal [book_zero, book_one, book_two], books
+  end
+
+  test "#find_all sorts by has_many association count descending" do
+    book_two = Book.create!(original_title: "Two Titles")
+    book_zero = Book.create!(original_title: "Zero Titles")
+    book_one = Book.create!(original_title: "One Title")
+    Title.create!(book: book_two, title: "A")
+    Title.create!(book: book_two, title: "B")
+    Title.create!(book: book_one, title: "C")
+
+    books = book_repository.find_all(sort_order: Uchi::SortOrder.new(:titles, :desc))
+
+    assert_equal [book_two, book_one, book_zero], books
+  end
+
+  test "#find_all sorts by has_and_belongs_to_many association count ascending" do
+    author_two = Author.create!(name: "Two Books")
+    author_zero = Author.create!(name: "Zero Books")
+    author_one = Author.create!(name: "One Book")
+    book_a = Book.create!(original_title: "Book A")
+    book_b = Book.create!(original_title: "Book B")
+    author_two.books = [book_a, book_b]
+    author_one.books = [book_a]
+
+    authors = habtm_author_repository.find_all(sort_order: Uchi::SortOrder.new(:books, :asc))
+
+    assert_equal [author_zero, author_one, author_two], authors
+  end
+
+  test "#find_all sorts by has_and_belongs_to_many association count descending" do
+    author_two = Author.create!(name: "Two Books")
+    author_zero = Author.create!(name: "Zero Books")
+    author_one = Author.create!(name: "One Book")
+    book_a = Book.create!(original_title: "Book A")
+    book_b = Book.create!(original_title: "Book B")
+    author_two.books = [book_a, book_b]
+    author_one.books = [book_a]
+
+    authors = habtm_author_repository.find_all(sort_order: Uchi::SortOrder.new(:books, :desc))
+
+    assert_equal [author_two, author_one, author_zero], authors
+  end
+
   test "#find returns a single record by its ID" do
     alice = Author.create!(name: "Alice")
 
@@ -184,6 +238,13 @@ class UchiRepositoryTest < ActiveSupport::TestCase
 
   def title_repository
     Uchi::Repositories::Title.new
+  end
+
+  def habtm_author_repository
+    Class.new(Uchi::Repository) do
+      define_singleton_method(:model) { Author }
+      define_method(:fields) { [Uchi::Field::HasAndBelongsToMany.new(:books)] }
+    end.new
   end
 
   def visibility_repository(*fields)

--- a/test/uchi/repository_test.rb
+++ b/test/uchi/repository_test.rb
@@ -38,7 +38,7 @@ class UchiRepositoryTest < ActiveSupport::TestCase
     sort_order = author_repository.default_sort_order
 
     assert sort_order.is_a?(Uchi::SortOrder)
-    assert_equal :id, sort_order.name
+    assert_equal :id, sort_order.column
     assert_equal :asc, sort_order.direction
   end
 

--- a/test/uchi/sort_order_test.rb
+++ b/test/uchi/sort_order_test.rb
@@ -8,14 +8,14 @@ class UchiSortOrderTest < ActiveSupport::TestCase
   test ".from_params defaults to ascending when direction isn't given" do
     sort_order = Uchi::SortOrder.from_params(sort: {by: :name})
     assert_instance_of Uchi::SortOrder, sort_order
-    assert_equal :name, sort_order.name
+    assert_equal :name, sort_order.column
     assert_equal :asc, sort_order.direction
   end
 
   test ".from_params returns a new SortOrder when both 'by' and 'direction' are given" do
     sort_order = Uchi::SortOrder.from_params(sort: {by: :born_on, direction: :desc})
     assert_instance_of Uchi::SortOrder, sort_order
-    assert_equal :born_on, sort_order.name
+    assert_equal :born_on, sort_order.column
     assert_equal :desc, sort_order.direction
   end
 


### PR DESCRIPTION
Given that we show the number of associated records, it makes sense to sort the associations by count, so that the most relevant ones are shown first.

With this change columns with HasMany and HasManyAndBelongsTo fields can now be succesfully sorted on index pages instead of giving an error.

Replaces #104 