### PR TITLE
Add platform for docs deployments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,7 @@ GEM
     erb (6.0.4)
     erubi (1.13.1)
     execjs (2.10.1)
+    ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
     globalid (1.3.0)
@@ -168,6 +169,8 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
+    nokogiri (1.19.4-aarch64-linux-gnu)
+      racc (~> 1.4)
     nokogiri (1.19.4-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.19.4-x86_64-linux-gnu)
@@ -264,6 +267,7 @@ GEM
       rubocop-ast (>= 1.47.1, < 2.0)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
+    sqlite3 (2.9.5-aarch64-linux-gnu)
     sqlite3 (2.9.5-arm64-darwin)
     sqlite3 (2.9.5-x86_64-linux-gnu)
     standard (1.55.0)
@@ -307,6 +311,7 @@ GEM
     zeitwerk (2.8.0)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin
   x86_64-linux
 


### PR DESCRIPTION
> Your bundle only supports platforms ["arm64-darwin", "x86_64-linux"]
> but your local platform is aarch64-linux. Add the current platform to
> the lockfile with `bundle lock --add-platform aarch64-linux` and try
> again.