### PR TITLE
Render Field::Text on :new actions by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow UI to use the full height of the viewport to prevent clipping popovers and dialogs.
 - BelongsTo fields for polymorphic associations no longer cause an error on edit and new pages. Instead, they just don't show up. This isn't exactly optimal, but for now we don't have an automated way of actually figuring out what ActiveRecord class they are associated with.
 - Scrolling could result in scrolling entirely past all the content. The inline scrolling of each individidual pane should now be much more robust.
+- Field::Text now renders on :new actions by default as expected.
 
 ### Removed
 

--- a/app/components/uchi/field/text.rb
+++ b/app/components/uchi/field/text.rb
@@ -27,7 +27,7 @@ module Uchi
       protected
 
       def default_on
-        [:edit, :show]
+        [:edit, :new, :show]
       end
 
       def default_searchable?

--- a/test/components/uchi/field/text_test.rb
+++ b/test/components/uchi/field/text_test.rb
@@ -15,7 +15,7 @@ module Uchi
       end
 
       test "has default options" do
-        assert_equal [:edit, :show], @field.on
+        assert_equal [:edit, :new, :show], @field.on
         assert @field.searchable?
         assert @field.sortable?
       end


### PR DESCRIPTION
We got a bit overzealous with the default `on` options for Field::Text and forgot to include `:new`. This commit fixes that oversight.