### PR TITLE
Fix mobile scrolling on index views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Index views were not scrollable on mobile viewports.
+
 
 ## 0.2.0
 

--- a/app/views/layouts/uchi/application.html.erb
+++ b/app/views/layouts/uchi/application.html.erb
@@ -15,10 +15,10 @@
     <%= render "layouts/uchi/stylesheets" %>
   </head>
 
-  <body class="antialiased bg-neutral-secondary-medium p-2 h-screen overflow-hidden md:flex md:p-0">
+  <body class="antialiased bg-neutral-secondary-medium p-2 md:h-screen md:overflow-hidden md:flex md:p-0">
     <%= render(partial: "uchi/navigation/main") %>
 
-    <main class="py-6 overflow-x-hidden grow md:px-6"><%= yield %></main>
+    <main class="py-6 overflow-x-hidden overflow-y-auto grow md:px-6"><%= yield %></main>
 
     <%= render "layouts/uchi/flash_messages" %>
   </body>


### PR DESCRIPTION
body had `h-screen overflow-hidden` applied unconditionally, trapping scroll on mobile where `md:flex` doesn't apply yet and main had no scroll container of its own.
